### PR TITLE
PGX-4231 : update Logo component

### DIFF
--- a/src/lib/Header/Header.stories.js
+++ b/src/lib/Header/Header.stories.js
@@ -60,7 +60,11 @@ storiesOf(folder.nav + 'Header', module)
                 <MenuHamburger isOpen={boolean(mainMenuIsOpenLabel, true)} />
 
                 <a href="#">
-                    <Logo hasBaseline={false} hasHoverRight={true}>
+                    <Logo
+                        hasBaseline={false}
+                        hasHoverRight={true}
+                        blockWidth={spaceOptions.sm}
+                    >
                         {logo}
                     </Logo>
                 </a>

--- a/src/lib/Header/style/index.js
+++ b/src/lib/Header/style/index.js
@@ -13,11 +13,6 @@ const HeaderBase = styled.header`
         }
     }
 
-    ${LogoBase} {
-        height: 100%;
-        width: 120px;
-    }
-
     @media (${props => props.theme.query.max.lg}) {
         .main-nav {
             ${headerStyle};

--- a/src/lib/Logo/Logo.js
+++ b/src/lib/Logo/Logo.js
@@ -4,7 +4,15 @@ import { spaceOptions } from '../../shared/constants';
 import { LogoBase } from './style';
 
 const Logo = props => {
-    return <LogoBase {...props}>{props.children}</LogoBase>;
+    const hasText = props.text && props.text.length;
+
+    return (
+        <LogoBase {...props}>
+            <span className="logo">{props.children}</span>
+
+            {hasText ? <span className="text">{props.text}</span> : null}
+        </LogoBase>
+    );
 };
 
 Logo.propTypes = {
@@ -15,6 +23,7 @@ Logo.propTypes = {
     hasHoverColor: PropTypes.bool,
     blockWidth: PropTypes.oneOf(Object.values(spaceOptions)),
     blockHeight: PropTypes.oneOf(Object.values(spaceOptions)),
+    text: PropTypes.string,
 };
 
 Logo.defaultProps = {

--- a/src/lib/Logo/Logo.js
+++ b/src/lib/Logo/Logo.js
@@ -5,6 +5,7 @@ import {
     colorThemeOptions,
     colorThemeDefault,
     gradientOptions,
+    blockWidthOptions,
 } from '../../shared/constants';
 import { LogoBase } from './style';
 
@@ -29,6 +30,7 @@ Logo.propTypes = {
     blockWidth: PropTypes.oneOf(Object.values(spaceOptions)),
     blockHeight: PropTypes.oneOf(Object.values(spaceOptions)),
     text: PropTypes.string,
+    textSize: PropTypes.oneOf(Object.values(blockWidthOptions)),
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
     gradient: PropTypes.oneOf(Object.values(gradientOptions)),
 };
@@ -41,6 +43,7 @@ Logo.defaultProps = {
     hasHoverColor: false,
     blockWidth: spaceOptions.none,
     blockHeight: spaceOptions.none,
+    textSize: blockWidthOptions.sm,
     colorTheme: colorThemeDefault,
     gradient: gradientOptions.theme,
 };

--- a/src/lib/Logo/Logo.js
+++ b/src/lib/Logo/Logo.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { spaceOptions } from '../../shared/constants';
+import {
+    spaceOptions,
+    colorThemeOptions,
+    colorThemeDefault,
+    gradientOptions,
+} from '../../shared/constants';
 import { LogoBase } from './style';
 
 const Logo = props => {
@@ -24,6 +29,8 @@ Logo.propTypes = {
     blockWidth: PropTypes.oneOf(Object.values(spaceOptions)),
     blockHeight: PropTypes.oneOf(Object.values(spaceOptions)),
     text: PropTypes.string,
+    colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
+    gradient: PropTypes.oneOf(Object.values(gradientOptions)),
 };
 
 Logo.defaultProps = {
@@ -34,6 +41,8 @@ Logo.defaultProps = {
     hasHoverColor: false,
     blockWidth: spaceOptions.none,
     blockHeight: spaceOptions.none,
+    colorTheme: colorThemeDefault,
+    gradient: gradientOptions.theme,
 };
 
 export default Logo;

--- a/src/lib/Logo/Logo.stories.js
+++ b/src/lib/Logo/Logo.stories.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
-import { folder, spaceOptions } from '../../shared/constants';
+import {
+    withKnobs,
+    boolean,
+    select,
+    radios,
+    text,
+} from '@storybook/addon-knobs';
+import {
+    folder,
+    spaceOptions,
+    colorThemeOptions,
+    colorThemeDefault,
+    gradientOptions,
+} from '../../shared/constants';
 import Logo from './Logo';
 import { logo } from './sample/logo';
 
@@ -10,14 +22,24 @@ storiesOf(folder.media + 'Logo', module)
     .add('Logo', () => (
         <a href="#">
             <Logo
+                text={text('Text', '')}
                 hasBaseline={boolean('With baseline', true)}
+                colorTheme={select(
+                    'Color theme',
+                    colorThemeOptions,
+                    colorThemeDefault,
+                )}
+                gradient={radios(
+                    'Gradient type',
+                    gradientOptions,
+                    gradientOptions.theme,
+                )}
                 isWhite={boolean('White', false)}
                 hasHoverRight={boolean('Hover right', true)}
                 hasHoverTop={boolean('Hover top', false)}
                 hasHoverColor={boolean('Hover color', false)}
                 blockWidth={select('Width', spaceOptions, spaceOptions.md)}
                 blockHeight={select('Height', spaceOptions, spaceOptions.none)}
-                text={text('Text', '')}
             >
                 {logo}
             </Logo>

--- a/src/lib/Logo/Logo.stories.js
+++ b/src/lib/Logo/Logo.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
 import { folder, spaceOptions } from '../../shared/constants';
 import Logo from './Logo';
 import { logo } from './sample/logo';
@@ -15,8 +15,9 @@ storiesOf(folder.media + 'Logo', module)
                 hasHoverRight={boolean('Hover right', true)}
                 hasHoverTop={boolean('Hover top', false)}
                 hasHoverColor={boolean('Hover color', false)}
-                blockWidth={select('Width', spaceOptions, spaceOptions.none)}
+                blockWidth={select('Width', spaceOptions, spaceOptions.md)}
                 blockHeight={select('Height', spaceOptions, spaceOptions.none)}
+                text={text('Text', '')}
             >
                 {logo}
             </Logo>

--- a/src/lib/Logo/Logo.stories.js
+++ b/src/lib/Logo/Logo.stories.js
@@ -13,6 +13,7 @@ import {
     colorThemeOptions,
     colorThemeDefault,
     gradientOptions,
+    blockWidthOptions,
 } from '../../shared/constants';
 import Logo from './Logo';
 import { logo } from './sample/logo';
@@ -40,6 +41,11 @@ storiesOf(folder.media + 'Logo', module)
                 hasHoverColor={boolean('Hover color', false)}
                 blockWidth={select('Width', spaceOptions, spaceOptions.md)}
                 blockHeight={select('Height', spaceOptions, spaceOptions.none)}
+                textSize={select(
+                    'Text size',
+                    blockWidthOptions,
+                    blockWidthOptions.sm,
+                )}
             >
                 {logo}
             </Logo>

--- a/src/lib/Logo/style/base.js
+++ b/src/lib/Logo/style/base.js
@@ -1,5 +1,32 @@
 import { css } from 'styled-components';
 
+const textSizeBases = {
+    sm: css`
+        font-size: ${props => props.theme.font.size.tiny};
+        padding: ${props => props.theme.space.xs};
+        margin-left: ${props => props.theme.space.sm};
+    `,
+    md: css`
+        font-size: ${props => props.theme.font.size.xxs};
+        padding: ${props => props.theme.space.xs};
+        margin-left: ${props => props.theme.space.md};
+    `,
+    lg: css`
+        font-size: ${props => props.theme.font.size.xs};
+        padding: ${props => props.theme.space.sm};
+        margin-left: ${props => props.theme.space.md};
+    `,
+};
+
+const textSize = {
+    none: css`${textSizeBases.lg}`,
+    xs: css`${textSizeBases.sm}`,
+    sm: css`${textSizeBases.sm}`,
+    md: css`${textSizeBases.sm}`,
+    lg: css`${textSizeBases.md}`,
+    xl: css`${textSizeBases.lg}`,
+};
+
 const textBackground = {
     brand: css`
         background-image: linear-gradient(to bottom right,
@@ -83,6 +110,7 @@ const hoverColorStyle = css`
 `;
 
 export {
+    textSize,
     coloredStyle,
     whiteStyle,
     noBaselineStyle,

--- a/src/lib/Logo/style/base.js
+++ b/src/lib/Logo/style/base.js
@@ -1,8 +1,38 @@
 import { css } from 'styled-components';
 
+const textBackground = {
+    brand: css`
+        background-image: linear-gradient(to bottom right,
+            ${props => props.theme.color.primary.main},
+            ${props => props.theme.color.secondary.main}
+        );
+    `,
+    theme: css`
+        background-image: linear-gradient(to bottom right,
+            ${props => props.theme.color[props.colorTheme].gradientBase},
+            ${props => props.theme.color[props.colorTheme].gradientShade}
+        );
+    `,
+    none: css`
+        background-color: ${props => props.theme.color[props.colorTheme].main};
+    `,
+}
+
+const coloredStyle = css`
+    .text {
+        color: ${props => props.theme.wab.white00};
+        ${props => textBackground[props.gradient]};
+    }
+`;
+
 const whiteStyle = css`
     svg {
         fill: ${props => props.theme.wab.white00};
+    }
+
+    .text {
+        color: ${props => props.theme.color[props.colorTheme].main};
+        background-color: ${props => props.theme.wab.white00};
     }
 `;
 
@@ -53,6 +83,7 @@ const hoverColorStyle = css`
 `;
 
 export {
+    coloredStyle,
     whiteStyle,
     noBaselineStyle,
     hoverRightStyle,

--- a/src/lib/Logo/style/base.js
+++ b/src/lib/Logo/style/base.js
@@ -9,7 +9,7 @@ const textSize = {
     md: css`
         font-size: ${props => props.theme.font.size.xxs};
         padding: ${props => props.theme.space.xs};
-        margin-left: ${props => props.theme.space.md};
+        margin-left: ${props => props.theme.space.sm};
     `,
     lg: css`
         font-size: ${props => props.theme.font.size.xs};

--- a/src/lib/Logo/style/base.js
+++ b/src/lib/Logo/style/base.js
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 
-const textSizeBases = {
+const textSize = {
     sm: css`
         font-size: ${props => props.theme.font.size.tiny};
         padding: ${props => props.theme.space.xs};
@@ -16,15 +16,11 @@ const textSizeBases = {
         padding: ${props => props.theme.space.sm};
         margin-left: ${props => props.theme.space.md};
     `,
-};
-
-const textSize = {
-    none: css`${textSizeBases.lg}`,
-    xs: css`${textSizeBases.sm}`,
-    sm: css`${textSizeBases.sm}`,
-    md: css`${textSizeBases.sm}`,
-    lg: css`${textSizeBases.md}`,
-    xl: css`${textSizeBases.lg}`,
+    xl: css`
+        font-size: ${props => props.theme.font.size.sm};
+        padding: ${props => props.theme.space.sm};
+        margin-left: ${props => props.theme.space.md};
+    `,
 };
 
 const textBackground = {

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
+import { spaceOptions } from '../../../shared/constants';
 import {
+    textSize,
     coloredStyle,
     whiteStyle,
     noBaselineStyle,
@@ -36,13 +38,16 @@ const LogoBase = styled.span`
 
     .text {
         border-radius: ${props => props.theme.radius.sm};
-        padding: ${props => props.theme.space.xs};
-        text-transform: uppercase;
-        font-size: ${props => props.theme.font.size.tiny};
-        font-weight: ${props => props.theme.font.weight.bold};
-        letter-spacing: ${props => props.theme.font.spacing};
-        margin-left: ${props => props.theme.space.sm};
         text-align: center;
+        text-transform: uppercase;
+        letter-spacing: ${props => props.theme.font.spacing};
+        font-weight: ${props => props.theme.font.weight.bold};
+        ${props =>
+            textSize[
+                props.blockWidth !== spaceOptions.none
+                    ? props.blockWidth
+                    : props.blockHeight
+            ]};
     }
 
     ${props => (props.isWhite ? whiteStyle : coloredStyle)};

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -4,17 +4,22 @@ import {
     noBaselineStyle,
     hoverRightStyle,
     hoverTopStyle,
-    hoverColorStyle
+    hoverColorStyle,
 } from './base';
 
 const LogoBase = styled.span`
     display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
     transition: all ${props => props.theme.transition.sm};
-    width: ${props => props.theme.logoWidth[props.blockWidth]};
-    height: ${props => props.theme.logoHeight[props.blockHeight]};
+
+    .logo {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        width: ${props => props.theme.logoWidth[props.blockWidth]};
+        height: ${props => props.theme.logoHeight[props.blockHeight]};
+    }
 
     img,
     svg {
@@ -26,11 +31,11 @@ const LogoBase = styled.span`
         max-width: 100%;
     }
 
-    ${props => props.isWhite ? whiteStyle : null};
-    ${props => props.hasBaseline ? null : noBaselineStyle};
-    ${props => props.hasHoverRight ? hoverRightStyle : null};
-    ${props => props.hasHoverTop ? hoverTopStyle : null};
-    ${props => props.hasHoverColor ? hoverColorStyle : null};
+    ${props => (props.isWhite ? whiteStyle : null)};
+    ${props => (props.hasBaseline ? null : noBaselineStyle)};
+    ${props => (props.hasHoverRight ? hoverRightStyle : null)};
+    ${props => (props.hasHoverTop ? hoverTopStyle : null)};
+    ${props => (props.hasHoverColor ? hoverColorStyle : null)};
 `;
 
 export { LogoBase };

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -13,8 +13,6 @@ const LogoBase = styled.span`
     display: flex;
     align-items: center;
     transition: all ${props => props.theme.transition.sm};
-    width: ${props => props.theme.logoWidth[props.blockWidth]};
-    height: ${props => props.theme.logoHeight[props.blockHeight]};
 
     .logo {
         display: flex;
@@ -22,7 +20,8 @@ const LogoBase = styled.span`
         justify-content: center;
         align-items: center;
         height: 100%;
-        flex: 1;
+        width: ${props => props.theme.logoWidth[props.blockWidth]};
+        height: ${props => props.theme.logoHeight[props.blockHeight]};
     }
 
     img,

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { spaceOptions } from '../../../shared/constants';
 import {
     textSize,
     coloredStyle,
@@ -42,12 +41,7 @@ const LogoBase = styled.span`
         text-transform: uppercase;
         letter-spacing: ${props => props.theme.font.spacing};
         font-weight: ${props => props.theme.font.weight.bold};
-        ${props =>
-            textSize[
-                props.blockWidth !== spaceOptions.none
-                    ? props.blockWidth
-                    : props.blockHeight
-            ]};
+        ${props => textSize[props.textSize]};
     }
 
     ${props => (props.isWhite ? whiteStyle : coloredStyle)};

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import {
+    coloredStyle,
     whiteStyle,
     noBaselineStyle,
     hoverRightStyle,
@@ -11,14 +12,16 @@ const LogoBase = styled.span`
     display: flex;
     align-items: center;
     transition: all ${props => props.theme.transition.sm};
+    width: ${props => props.theme.logoWidth[props.blockWidth]};
+    height: ${props => props.theme.logoHeight[props.blockHeight]};
 
     .logo {
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        width: ${props => props.theme.logoWidth[props.blockWidth]};
-        height: ${props => props.theme.logoHeight[props.blockHeight]};
+        height: 100%;
+        flex: 1;
     }
 
     img,
@@ -31,7 +34,18 @@ const LogoBase = styled.span`
         max-width: 100%;
     }
 
-    ${props => (props.isWhite ? whiteStyle : null)};
+    .text {
+        border-radius: ${props => props.theme.radius.sm};
+        padding: ${props => props.theme.space.xs};
+        text-transform: uppercase;
+        font-size: ${props => props.theme.font.size.tiny};
+        font-weight: ${props => props.theme.font.weight.bold};
+        letter-spacing: ${props => props.theme.font.spacing};
+        margin-left: ${props => props.theme.space.sm};
+        text-align: center;
+    }
+
+    ${props => (props.isWhite ? whiteStyle : coloredStyle)};
     ${props => (props.hasBaseline ? null : noBaselineStyle)};
     ${props => (props.hasHoverRight ? hoverRightStyle : null)};
     ${props => (props.hasHoverTop ? hoverTopStyle : null)};

--- a/src/lib/Logo/style/index.js
+++ b/src/lib/Logo/style/index.js
@@ -19,7 +19,6 @@ const LogoBase = styled.span`
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        height: 100%;
         width: ${props => props.theme.logoWidth[props.blockWidth]};
         height: ${props => props.theme.logoHeight[props.blockHeight]};
     }

--- a/src/theme/theme.base.js
+++ b/src/theme/theme.base.js
@@ -185,8 +185,8 @@ export const ThemeBase = {
     },
     logoWidth: {
         none: 'auto',
-        xs: '70px',
-        sm: '100px',
+        xs: '90px',
+        sm: '120px',
         md: '150px',
         lg: '200px',
         xl: '250px',


### PR DESCRIPTION
- Ajout de props `text` et `textSize` pour ajouter un badge à un Logo
- Edit Header pour retirer le CSS custom : désormais, la taille du Logo doit être définie par une props sur le Logo dans le Header

**Pour tester :** 
Aller sur le composant Logo et renseigner un texte (par exemple : FAQ). Modifier les tailles du blockWidth et du textSize pour vérifier que tout va bien.
Note : un logo en blockWidth sm ira bien avec un textSize md, ces deux valeurs ne sont pas identiques.
Penser aussi à tester le Header qui contient un logo.