### PR TITLE
PGF-287: custom corner popin position

### DIFF
--- a/src/lib/Corner/Corner.js
+++ b/src/lib/Corner/Corner.js
@@ -44,6 +44,7 @@ const Corner = ({ children, label, ...rest }) => {
 Corner.propTypes = {
     label: PropTypes.string.isRequired,
     cornerPosition: PropTypes.oneOf(Object.values(cornerPositionOptions)),
+    hasCenteredPopin: PropTypes.bool,
     radiusSize: PropTypes.oneOf(Object.values(radiusOptions)),
     colorStyle: PropTypes.oneOf(Object.values(colorStyleOptions)),
     colorPallet: PropTypes.oneOf([
@@ -56,6 +57,7 @@ Corner.propTypes = {
 
 Corner.defaultProps = {
     cornerPosition: cornerPositionDefault,
+    hasCenteredPopin: false,
     radiusSize: radiusDefault,
     colorStyle: colorStyleDefault,
     colorPallet: colorPalletDefault,

--- a/src/lib/Corner/Corner.stories.js
+++ b/src/lib/Corner/Corner.stories.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, radios, select } from '@storybook/addon-knobs';
+import {
+    withKnobs,
+    text,
+    radios,
+    select,
+    boolean,
+} from '@storybook/addon-knobs';
 import {
     folder,
     cornerPositionOptions,
@@ -71,6 +77,7 @@ storiesOf(folder.main + 'Corner', module)
                 cornerPositionOptions,
                 cornerPositionDefault,
             )}
+            hasCenteredPopin={boolean('Centered popin', false)}
             radiusSize={select(radiusSizeLabel, radiusOptions, radiusDefault)}
             colorStyle={radios(
                 colorStyleLabel,

--- a/src/lib/Corner/__snapshots__/Corner.test.js.snap
+++ b/src/lib/Corner/__snapshots__/Corner.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="sc-AxirZ ixEyso"
+  className="sc-AxirZ iKMxwp"
 >
   <div
     className="corner"

--- a/src/lib/Corner/style/base.js
+++ b/src/lib/Corner/style/base.js
@@ -37,7 +37,17 @@ const positionStyle = {
         left: 0;
     `,
     right: css`
+        left: inherit;
         right: 0;
+    `,
+};
+
+const centeredPopinStyle = {
+    left: css`
+        transform: translateX(-50%);
+    `,
+    right: css`
+        transform: translateX(50%);
     `,
 };
 
@@ -110,4 +120,11 @@ const bannerStyle = css`
     }
 `;
 
-export { backgroundStyle, colorStyle, positionStyle, squareStyle, bannerStyle };
+export {
+    backgroundStyle,
+    colorStyle,
+    positionStyle,
+    centeredPopinStyle,
+    squareStyle,
+    bannerStyle,
+};

--- a/src/lib/Corner/style/index.js
+++ b/src/lib/Corner/style/index.js
@@ -4,6 +4,7 @@ import {
     backgroundStyle,
     colorStyle,
     positionStyle,
+    centeredPopinStyle,
     squareStyle,
     bannerStyle,
 } from './base';
@@ -31,10 +32,14 @@ const CornerBase = styled.div`
     ${PopinBase} {
         opacity: 0;
         pointer-events: none;
-        left: inherit;
         ${props => positionStyle[props.cornerPosition]};
+        ${props =>
+            props.hasCenteredPopin
+                ? centeredPopinStyle[props.cornerPosition]
+                : null};
 
-        &::before { /* add transparent zone above Popin to improve hover behaviour */
+        &::before {
+            /* add transparent zone above Popin to improve hover behaviour */
             content: '';
             position: absolute;
             width: 100%;

--- a/src/lib/Main/style/base.js
+++ b/src/lib/Main/style/base.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
 const isOpenStyle = css`
-    margin-left: 100%;
+    margin-left: 110%; /* 10% margin in order to mask Main shadow */
 
     @media (${props => props.theme.query.min.md}) {
         margin-left: ${props => props.theme.grid.sidebar};


### PR DESCRIPTION
Ajout d'une props hasCenteredPopin sur le composant Corner pour permettre de centrer la popin par rapport au Corner (utile en particulier sur les versions mobiles).

Fix visuel sur l'ombre visible du Main fermé.