### PR TITLE
PGF-251 : add isOpen props on MenuClose component

### DIFF
--- a/src/lib/Grid/style/base.js
+++ b/src/lib/Grid/style/base.js
@@ -114,7 +114,7 @@ const displayStyle = {
             padding-top: ${props => props.theme.space[props.childrenMarginBig]};
             width: fit-content;
             columns: ${props => props.columnNumber - 1};
-            gap: 0;
+            gap: ${props => props.theme.blockSpace[props.gridGap]};
 
             & > * {
                 padding: ${props => props.theme.space[props.childrenMarginBig]};

--- a/src/lib/MenuClose/MenuClose.js
+++ b/src/lib/MenuClose/MenuClose.js
@@ -4,6 +4,7 @@ import {
     colorThemeOptions,
     colorThemeDefault,
     iconSizeOptions,
+    rotateSizeOptions,
 } from '../../shared/constants';
 import { ArrowTopIcon } from '../Icon/Icon';
 import { MenuCloseBase } from './style';
@@ -15,6 +16,9 @@ const MenuClose = props => {
                 theme={props.theme} // not necessary, only needed for tests
                 iconSize={iconSizeOptions.lg}
                 colorTheme={props.colorTheme}
+                rotateSize={
+                    props.isOpen ? rotateSizeOptions.d0 : rotateSizeOptions.d180
+                }
             />
 
             <svg className="background" viewBox="0 0 170 28.8">
@@ -26,10 +30,12 @@ const MenuClose = props => {
 
 MenuClose.propTypes = {
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
+    isOpen: PropTypes.bool,
 };
 
 MenuClose.defaultProps = {
     colorTheme: colorThemeDefault,
+    isOpen: true,
 };
 
 export default MenuClose;

--- a/src/lib/MenuClose/MenuClose.stories.js
+++ b/src/lib/MenuClose/MenuClose.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, radios } from '@storybook/addon-knobs';
+import { withKnobs, radios, boolean } from '@storybook/addon-knobs';
 import {
     folder,
     colorThemeOptions,
@@ -13,5 +13,6 @@ storiesOf(folder.nav + folder.sub.control + 'MenuClose', module)
     .add('MenuClose', () => (
         <MenuClose
             colorTheme={radios('Color', colorThemeOptions, colorThemeDefault)}
+            isOpen={boolean('Is open', true)}
         />
     ));


### PR DESCRIPTION
Ajout d'une props isOpen sur le composant MenuClose pour pouvoir tourner la flèche dans le bon sens dans une Card qui le contient (exemple : BO Green card des projets).

Customisation du gap des colonnes dans la Grid.