### PR TITLE
PGF-553: fix media queries

### DIFF
--- a/src/lib/Button/style/index.js
+++ b/src/lib/Button/style/index.js
@@ -1,31 +1,32 @@
 import styled from 'styled-components';
 import { math } from 'polished';
 import { colorTypeOptions } from '../../../shared/constants';
-import {
-    enabled,
-    disabled,
-    templateStyle
-} from './base';
+import { enabled, disabled, templateStyle } from './base';
 
 const ButtonBase = styled.span`
-    ${props => props.isDisabled ? disabled : enabled};
+    ${props => (props.isDisabled ? disabled : enabled)};
     ${props => templateStyle[props.buttonStyle]};
 
     display: inline-block;
     position: relative;
     z-index: ${props => props.theme.zindex.base};
-    padding: ${props => props.theme.button.paddingHeight[props.buttonSize]} ${props => props.theme.button.paddingWidth[props.buttonSize]};
+    padding: ${props =>
+        props.theme.button.paddingHeight[props.buttonSize] +
+        ' ' +
+        props.theme.button.paddingWidth[props.buttonSize]};
     margin: ${props => props.theme.button.shift};
     transition: all ${props => props.theme.transition.xs};
     text-align: center;
     text-transform: uppercase;
-    letter-spacing: ${props => props.theme.button.letterSpacing[props.buttonSize]};
+    letter-spacing: ${props =>
+        props.theme.button.letterSpacing[props.buttonSize]};
     line-height: ${props => props.theme.font.lineHeight.md};
     font-weight: ${props => props.theme.font.weight.bold};
     font-size: ${props => props.theme.button.font[props.buttonSize]};
 
-    @media (${props => props.theme.query.max.md}) {
-        font-size: ${props => math(props.theme.button.font[props.buttonSize] + '- 0.1')};
+    @media ${props => props.theme.screen.max.md} {
+        font-size: ${props =>
+            math(props.theme.button.font[props.buttonSize] + '- 0.1')};
     }
 
     &::before,
@@ -36,10 +37,11 @@ const ButtonBase = styled.span`
         height: 100%;
         width: 100%;
         border-radius: ${props => props.theme.radius.sm};
-        opacity: ${props => props.colorType === colorTypeOptions.reverse ? 0.6 : 0.5};
-        transition:
-            all ${props => props.theme.transition.xs},
-            opacity ${props => props.theme.transition.sm} linear ${props => props.theme.transition.xs};
+        opacity: ${props =>
+            props.colorType === colorTypeOptions.reverse ? 0.6 : 0.5};
+        transition: all ${props => props.theme.transition.xs},
+            opacity ${props => props.theme.transition.sm} linear
+                ${props => props.theme.transition.xs};
     }
 
     &::before {

--- a/src/lib/ClickableBlock/style/index.js
+++ b/src/lib/ClickableBlock/style/index.js
@@ -15,7 +15,7 @@ const ClickableBlockBase = styled.div`
     transition: all ${props => props.theme.transition.xs};
 
     .arrow {
-        @media (${props => props.theme.query.max.md}) {
+        @media ${props => props.theme.screen.max.md} {
             display: ${props => (props.isHiddenOnMobile ? 'none' : null)};
         }
     }

--- a/src/lib/DaTable/style/index.js
+++ b/src/lib/DaTable/style/index.js
@@ -5,11 +5,11 @@ const DaTableBase = styled.div`
     ${responsiveSpaces('margin')};
     color: ${props => props.theme.wab.grey60};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         max-width: ${props => props.theme.blockWidth[props.blockWidth]};
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         display: table;
     }
 `;

--- a/src/lib/DaTableBody/style/index.js
+++ b/src/lib/DaTableBody/style/index.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const DaTableBodyBase = styled.div`
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         display: table-row-group;
         background-color: ${props => props.theme.wab.white10};
     }

--- a/src/lib/DaTableCell/style/index.js
+++ b/src/lib/DaTableCell/style/index.js
@@ -6,12 +6,12 @@ const DaTableCellBase = styled.div`
     font-size: ${props => props.theme.font.size.xs};
     padding: ${props => props.theme.space.xs};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         ${props => (props.isId ? idStyle : null)};
         ${props => (props.isMain ? mainStyle : notMainStyle)};
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         position: relative;
         display: table-cell;
         vertical-align: middle;
@@ -39,7 +39,7 @@ const DaTableCellBase = styled.div`
     }
 
     .cell-label {
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             display: none;
         }
     }

--- a/src/lib/DaTableHead/style/index.js
+++ b/src/lib/DaTableHead/style/index.js
@@ -5,7 +5,7 @@ import { TextBase } from '../../Text/style';
 import { openStyle, closedStyle } from './base';
 
 const DaTableHeadBase = styled.div`
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         margin: ${props => props.theme.space.xs};
         margin-bottom: ${props => props.theme.space.sm};
         padding: ${props => props.theme.space.sm};
@@ -22,7 +22,7 @@ const DaTableHeadBase = styled.div`
         ${props => (props.isHeadOpen ? openStyle : closedStyle)};
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         display: table-header-group;
     }
 
@@ -32,7 +32,7 @@ const DaTableHeadBase = styled.div`
 
     ${InternalGridBase},
     ${TextBase} {
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             display: none;
         }
     }

--- a/src/lib/DaTableHeadCell/style/base.js
+++ b/src/lib/DaTableHeadCell/style/base.js
@@ -3,7 +3,7 @@ import { math } from 'polished';
 import { IconBase } from '../../Icon/style';
 
 const isCheckboxStyle = css`
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         font-size: 0; /* remove cell label when it's only a select/deselect all Checkbox */
     }
 `;
@@ -11,7 +11,7 @@ const isCheckboxStyle = css`
 const calcShift = props => props.theme.icon.shift.sm;
 
 const mobileStyle = css`
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         white-space: nowrap;
 
         .head-child {
@@ -70,7 +70,7 @@ const mobileStyle = css`
 `;
 
 const hideUselessCell = css`
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         display: none;
     }
 `;

--- a/src/lib/DaTableHeadCell/style/index.js
+++ b/src/lib/DaTableHeadCell/style/index.js
@@ -8,7 +8,7 @@ const DaTableHeadCellBase = styled.div`
     font-size: ${props => props.theme.font.size.xs};
     font-weight: ${props => props.theme.font.weight.bold};
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         display: table-cell;
         padding: ${props => props.theme.space.sm + ' ' + props.theme.space.md};
         padding-top: 0;

--- a/src/lib/DaTableRow/style/base.js
+++ b/src/lib/DaTableRow/style/base.js
@@ -75,7 +75,7 @@ const hoverStyle = css`
         )};
     background-color: ${props => transparentize(1, props.theme.wab.white10)};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         background-color: ${props => props.theme.wab.white10};
     }
 
@@ -89,7 +89,7 @@ const hoverStyle = css`
             )};
         background-color: ${props => props.theme.wab.white00};
 
-        @media (${props => props.theme.query.max.lg}) {
+        @media ${props => props.theme.screen.max.lg} {
             background-color: ${props => props.theme.wab.white00};
         }
     }
@@ -99,7 +99,7 @@ const activeStyle = css`
     font-weight: ${props => props.theme.font.weight.bold};
     background-color: ${props => props.theme.wab.grey10};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         background-color: ${props => props.theme.wab.grey10};
     }
 `;

--- a/src/lib/DaTableRow/style/index.js
+++ b/src/lib/DaTableRow/style/index.js
@@ -12,7 +12,7 @@ const DaTableRowBase = styled.div`
         margin: ${props => props.theme.space.xs} 0;
     }
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         margin: ${props => props.theme.space.xs};
         padding: ${props => props.theme.space.xs};
         border-radius: ${props => props.theme.radius.sm};
@@ -32,7 +32,7 @@ const DaTableRowBase = styled.div`
         ${toggableStyle};
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         display: table-row;
 
         .cell-checkbox {

--- a/src/lib/DataLegend/style/index.js
+++ b/src/lib/DataLegend/style/index.js
@@ -7,7 +7,7 @@ const DataLegendBase = styled.div`
     color: ${props => props.theme.wab.grey60};
     font-size: ${props => props.theme.font.size[props.textSize]};
 
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         font-size: ${props =>
             props.theme.font.size[minimizeFont[props.textSize]]};
     }

--- a/src/lib/Divider/style/base.js
+++ b/src/lib/Divider/style/base.js
@@ -10,13 +10,13 @@ const structureBase = css`
 `;
 
 const withText = css`
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         .shape {
             display: none;
         }
     }
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         ${structureBase};
     }
 `;

--- a/src/lib/Divider/style/index.js
+++ b/src/lib/Divider/style/index.js
@@ -16,7 +16,7 @@ const DividerBase = styled.div`
         font-weight: ${props => props.theme.font.weight.bold};
         font-size: ${props => props.theme.font.size.md};
 
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             font-size: ${props => props.theme.font.size.lg};
         }
     }

--- a/src/lib/FooterList/style/index.js
+++ b/src/lib/FooterList/style/index.js
@@ -10,7 +10,7 @@ const FooterListBase = styled.ul`
     line-height: ${props => props.theme.font.lineHeight.md};
 
     & > li {
-        @media (${props => props.theme.query.max.lg}) {
+        @media ${props => props.theme.screen.max.lg} {
             margin-top: ${props => props.theme.space.sm};
             margin-bottom: ${props => props.theme.space.sm};
         }

--- a/src/lib/GlobalStyle/GlobalStyle.js
+++ b/src/lib/GlobalStyle/GlobalStyle.js
@@ -11,7 +11,7 @@ const blockedScroll = {
         overflow-y: scroll !important;
     `,
     mobile: css`
-        @media (${props => props.theme.query.max.lg}) {
+        @media ${props => props.theme.screen.max.lg} {
             ${baseBodyStyle};
             overflow-y: scroll !important;
         }
@@ -23,7 +23,7 @@ const noScroll = {
         ${baseBodyStyle};
     `,
     mobile: css`
-        @media (${props => props.theme.query.max.lg}) {
+        @media ${props => props.theme.screen.max.lg} {
             ${baseBodyStyle};
         }
     `,

--- a/src/lib/Grid/style/base.js
+++ b/src/lib/Grid/style/base.js
@@ -19,7 +19,7 @@ const childrenMargins = css`
     & > * {
         margin: ${props => props.theme.space[props.childrenMargin]} auto !important;
 
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             margin: ${props => props.theme.space[props.childrenMarginBig]} !important;
         }
     }
@@ -33,7 +33,7 @@ const gridGap = css`
             'space',
         )};
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         gap: ${props =>
             blockSpace(
                 'md',
@@ -53,19 +53,19 @@ const gridStyles = css`
 
 const gridTemplate = {
     custom: css`
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             grid-template-columns: ${props => props.gridTemplateColumns};
         }
     `,
     auto: css`
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             grid-template-columns: repeat(
                 ${props => props.columnNumber - 1},
                 1fr
             );
         }
 
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             grid-template-columns: repeat(${props => props.columnNumber}, 1fr);
         }
     `,
@@ -73,7 +73,7 @@ const gridTemplate = {
 
 const displayStyle = {
     flex: css`
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             display: flex;
             flex-direction: ${props => props.flexDirection};
             flex-wrap: ${props => props.flexWrap};
@@ -88,7 +88,7 @@ const displayStyle = {
         ${childrenMargins};
     `,
     grid: css`
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             ${gridStyles};
         }
 
@@ -110,7 +110,7 @@ const displayStyle = {
             }
         }
 
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             padding-top: ${props => props.theme.space[props.childrenMarginBig]};
             width: fit-content;
             columns: ${props => props.columnNumber - 1};
@@ -127,7 +127,7 @@ const displayStyle = {
             }
         }
 
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             columns: ${props => props.columnNumber};
         }
     `,
@@ -148,7 +148,7 @@ function childrenShift(count, shiftSize, isNegative, isReverse) {
 
     return css`
         & > * {
-            @media (${props => props.theme.query.min.xl}) {
+            @media ${props => props.theme.screen.min.xl} {
                 ${styles};
             }
         }

--- a/src/lib/Grid/style/index.js
+++ b/src/lib/Grid/style/index.js
@@ -10,7 +10,7 @@ const GridBase = styled.div`
         max-width: ${props => props.theme.grid.maxWidth};
     }
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         padding: 0;
         ${props => gridAlign[props.align]};
     }

--- a/src/lib/Header/style/base.js
+++ b/src/lib/Header/style/base.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 
 const topStyle = css`
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         box-shadow: unset;
     }
 `;

--- a/src/lib/List/style/index.js
+++ b/src/lib/List/style/index.js
@@ -7,13 +7,13 @@ const ListBase = styled.ul`
     padding: .1px 0;
     ${responsiveSpaces('margin')};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         .dashed {
             display: none;
         }
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         ${props => props.hasDashed ? dashedStyle : null};
     }
 `;

--- a/src/lib/ListItem/style/base.js
+++ b/src/lib/ListItem/style/base.js
@@ -107,7 +107,7 @@ const clickableStyle = css`
     ${props => (props.isClicked ? activeStyle : disabledStyle)};
     width: 100%; /* Fix for button tag */
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         margin-top: ${props => props.theme.space.sm};
         margin-bottom: ${props => props.theme.space.sm};
     }

--- a/src/lib/Main/style/base.js
+++ b/src/lib/Main/style/base.js
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 
 const isOpenStyle = css`
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         margin-left: 100%;
         box-shadow: 0 0 0 transparent;
     }
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         margin-left: ${props => props.theme.grid.sidebar};
         width: calc(100% - ${props => props.theme.grid.sidebar});
     }

--- a/src/lib/Menu/style/index.js
+++ b/src/lib/Menu/style/index.js
@@ -10,7 +10,7 @@ const MenuBase = styled.li`
         display: block;
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         ${MenuListBase} {
             margin-left: 50%;
             transform: translateX(-50%) scale(0);

--- a/src/lib/MenuGroup/style/base.js
+++ b/src/lib/MenuGroup/style/base.js
@@ -8,7 +8,7 @@ import { LogoBase } from '../../Logo/style';
 const hiddenStyle = css`
     margin-top: -${props => props.theme.grid.header};
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         ${MenuListBase} {
             display: none;
         }

--- a/src/lib/MenuGroup/style/index.js
+++ b/src/lib/MenuGroup/style/index.js
@@ -12,7 +12,7 @@ const MenuGroupBase = styled.div`
         }
     }
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         .main-nav {
             ${headerStyle};
             ${props =>
@@ -24,7 +24,7 @@ const MenuGroupBase = styled.div`
         }
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         ${headerStyle};
         ${props => (props.isHidden ? hiddenStyle : null)};
         ${props => (props.hasTopStyle ? topStyle : null)};

--- a/src/lib/MenuItem/style/base.js
+++ b/src/lib/MenuItem/style/base.js
@@ -8,7 +8,7 @@ const noClickableStyle = css`
     border-bottom: solid
         ${props => props.theme.line + ' ' + props.theme.wab.white20};
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         color: ${props => props.theme.wab.grey40};
         border: none;
     }
@@ -19,7 +19,7 @@ const isClickableStyle = css`
     overflow-x: hidden;
     color: ${props => props.theme.color[props.colorTheme].main};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         padding-right: ${props => props.theme.space.md};
 
         &::before {
@@ -48,7 +48,7 @@ const isClickableStyle = css`
         }
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         &::after {
             content: '';
             position: absolute;
@@ -70,7 +70,7 @@ const isClickableStyle = css`
     a:hover &,
     a:active &,
     a:focus & {
-        @media (${props => props.theme.query.max.lg}) {
+        @media ${props => props.theme.screen.max.lg} {
             padding-left: ${props => props.theme.space.md};
             padding-right: ${props => props.theme.space.sm};
 
@@ -79,7 +79,7 @@ const isClickableStyle = css`
             }
         }
 
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             &::after {
                 width: 100%;
             }

--- a/src/lib/MenuItem/style/index.js
+++ b/src/lib/MenuItem/style/index.js
@@ -23,7 +23,7 @@ const MenuItemBase = styled.div`
         }
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         flex-direction: column;
         justify-content: center;
         z-index: ${props => props.theme.zindex.menu};

--- a/src/lib/MenuList/style/index.js
+++ b/src/lib/MenuList/style/index.js
@@ -6,7 +6,7 @@ const MenuListBase = styled.ul`
     margin: 0;
     padding: ${props => props.theme.space.sm} 0;
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         position: absolute;
         top: 100%;
         left: 0;

--- a/src/lib/MenuPrimary/style/base.js
+++ b/src/lib/MenuPrimary/style/base.js
@@ -7,7 +7,7 @@ const menuBlock = css`
     box-sizing: border-box;
     margin: 0;
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         position: fixed;
         overflow-y: auto;
         left: 0;
@@ -35,7 +35,7 @@ const menuBlock = css`
         }
     }
 
-    @media (${props => props.theme.query.min.lg}) {
+    @media ${props => props.theme.screen.min.lg} {
         position: relative;
         display: flex;
         padding: 0;

--- a/src/lib/MenuPrimary/style/index.js
+++ b/src/lib/MenuPrimary/style/index.js
@@ -4,7 +4,7 @@ import { menuBlock, closedStyle } from './base';
 const MenuPrimaryBase = styled.ul`
     ${menuBlock};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         height: calc(100vh - ${props => props.theme.grid.header});
         padding: ${props => props.theme.space.sm} 0;
 

--- a/src/lib/MenuSecondary/style/index.js
+++ b/src/lib/MenuSecondary/style/index.js
@@ -10,7 +10,7 @@ import { MenuCloseBase } from '../../MenuClose/style';
 const MenuSecondaryBase = styled.div`
     ${menuBlock};
 
-    @media (${props => props.theme.query.max.lg}) {
+    @media ${props => props.theme.screen.max.lg} {
         max-height: calc(100vh - ${props => props.theme.grid.header});
         box-shadow: 0 3px 20px
             ${props =>
@@ -26,7 +26,7 @@ const MenuSecondaryBase = styled.div`
         margin: 0;
         padding: ${props => props.theme.space.sm} 0;
 
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             display: flex;
             padding: 0;
         }
@@ -36,13 +36,13 @@ const MenuSecondaryBase = styled.div`
             margin: 0;
             padding: 0;
 
-            @media (${props => props.theme.query.min.lg}) {
+            @media ${props => props.theme.screen.min.lg} {
                 display: flex;
                 align-items: center;
             }
 
             & > ${MenuBase} {
-                @media (${props => props.theme.query.min.lg}) {
+                @media ${props => props.theme.screen.min.lg} {
                     position: relative;
                     display: flex;
                     align-items: center;
@@ -55,19 +55,19 @@ const MenuSecondaryBase = styled.div`
     ${MenuCloseBase} {
         margin: ${props => props.theme.space.md} auto 0 auto;
 
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             display: none;
         }
     }
 
     ${MenuListBase} {
-        @media (${props => props.theme.query.min.lg}) {
+        @media ${props => props.theme.screen.min.lg} {
             width: auto;
             min-width: 100%;
         }
 
         ${LinkBase} {
-            @media (${props => props.theme.query.min.lg}) {
+            @media ${props => props.theme.screen.min.lg} {
                 white-space: nowrap;
             }
         }

--- a/src/lib/Message/style/base.js
+++ b/src/lib/Message/style/base.js
@@ -78,11 +78,11 @@ const arrowBlockStyle = {
         ${rightStyle};
     `,
     left: css`
-        @media (${props => props.theme.query.max[arrowBreakpoint]}) {
+        @media ${props => props.theme.screen.max[arrowBreakpoint]} {
             ${topLeftStyle};
         }
 
-        @media (${props => props.theme.query.min[arrowBreakpoint]}) {
+        @media ${props => props.theme.screen.min[arrowBreakpoint]} {
             margin-left: ${arrowSize};
 
             &::after {
@@ -93,11 +93,11 @@ const arrowBlockStyle = {
         }
     `,
     right: css`
-        @media (${props => props.theme.query.max[arrowBreakpoint]}) {
+        @media ${props => props.theme.screen.max[arrowBreakpoint]} {
             ${bottomLeftStyle};
         }
 
-        @media (${props => props.theme.query.min[arrowBreakpoint]}) {
+        @media ${props => props.theme.screen.min[arrowBreakpoint]} {
             margin-right: ${arrowSize};
 
             &::after {

--- a/src/lib/ModalContent/style/index.js
+++ b/src/lib/ModalContent/style/index.js
@@ -19,7 +19,7 @@ const ModalContentBase = styled.div`
         ' ' +
         transparentize(props.theme.shadow.opacity.md, props.theme.wab.black00)};
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         max-width: ${props => props.theme.blockWidth[props.blockWidth]};
         border-radius: ${props => props.theme.radius.lg};
         position: relative;

--- a/src/lib/RadioIcon/style/base.js
+++ b/src/lib/RadioIcon/style/base.js
@@ -31,7 +31,7 @@ const labelSize = {
     lg: css`
         width: ${props => props.theme.form.radio.md};
 
-        @media (${props => props.theme.query.min.sm}) {
+        @media ${props => props.theme.screen.min.sm} {
             width: ${props => props.theme.form.radio.lg};
         }
 
@@ -44,7 +44,7 @@ const labelSize = {
             height: 100%;
             min-height: ${props => props.theme.form.radio.md};
 
-            @media (${props => props.theme.query.min.sm}) {
+            @media ${props => props.theme.screen.min.sm} {
                 min-height: ${props => props.theme.form.radio.lg};
             }
 

--- a/src/lib/Sidebar/style/index.js
+++ b/src/lib/Sidebar/style/index.js
@@ -8,7 +8,7 @@ const SidebarBase = styled.div`
     width: 100%;
     overflow-y: hidden;
 
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         display: grid;
         grid-template-rows: auto 1fr;
         grid-template-areas: 'topbar' 'box';
@@ -23,7 +23,7 @@ const SidebarBase = styled.div`
         }
     }
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         width: ${props => props.theme.grid.sidebar};
         overflow-y: auto;
     }

--- a/src/lib/Table/style/base.js
+++ b/src/lib/Table/style/base.js
@@ -24,11 +24,11 @@ const backgroundStyle = css`
     )};
     padding: ${props => props.theme.space.sm};
 
-    @media (${props => props.theme.query.min.md}) {
+    @media ${props => props.theme.screen.min.md} {
         padding: ${props => props.theme.space.md};
     }
 
-    @media (${props => props.theme.query.min.xl}) {
+    @media ${props => props.theme.screen.min.xl} {
         padding: ${props => props.theme.space.lg};
     }
 `;

--- a/src/lib/TableCell/style/index.js
+++ b/src/lib/TableCell/style/index.js
@@ -10,7 +10,7 @@ const TableCellBase = styled.div`
     padding: ${props => props.theme.space.sm} ${props => props.theme.space.md};
     color: ${props => props.theme.wab.grey60};
 
-    @media (${props => props.theme.query.max.sm}) {
+    @media ${props => props.theme.screen.max.sm} {
         font-size: 0.85em;
     }
 
@@ -23,7 +23,7 @@ const TableCellBase = styled.div`
             margin-right: ${props => props.theme.space.md};
         }
 
-        @media (${props => props.theme.query.max.md}) {
+        @media ${props => props.theme.screen.max.md} {
             display: none;
         }
     }
@@ -37,7 +37,7 @@ const TableCellBase = styled.div`
         font-size: ${props => props.theme.font.size.xs};
         font-style: italic;
 
-        @media (${props => props.theme.query.max.md}) {
+        @media ${props => props.theme.screen.max.md} {
             display: none;
         }
     }

--- a/src/lib/TableRow/style/index.js
+++ b/src/lib/TableRow/style/index.js
@@ -9,7 +9,7 @@ const TableRowBase = styled.div`
     &:first-of-type {
         ${TableCellBase} {
             &:not(:first-of-type) {
-                @media (${props => props.theme.query.max.md}) {
+                @media ${props => props.theme.screen.max.md} {
                     vertical-align: bottom;
 
                     .content {

--- a/src/lib/Text/style/base.js
+++ b/src/lib/Text/style/base.js
@@ -40,7 +40,7 @@ const htmlTagStyle = {
         font-size: ${props =>
             math(props.theme.font.size[props.textSize] + '* 0.7')};
 
-        @media (${props => props.theme.query.max.md}) {
+        @media ${props => props.theme.screen.max.md} {
             font-size: ${props =>
                 math(props.theme.font.size[props.textSize] + '* 0.6')};
         }

--- a/src/lib/Text/style/index.js
+++ b/src/lib/Text/style/index.js
@@ -10,7 +10,7 @@ const TextBase = styled.p`
     text-align: ${props => props.align};
     font-size: ${props => props.theme.font.size[props.textSize]};
 
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         font-size: ${props =>
             props.theme.font.size[minimizeFont[props.textSize]]};
     }

--- a/src/lib/Title/style/base.js
+++ b/src/lib/Title/style/base.js
@@ -10,7 +10,7 @@ const smallText = css`
 `;
 
 const bigText = css`
-    @media (${props => props.theme.query.max.md}) {
+    @media ${props => props.theme.screen.max.md} {
         font-size: ${props =>
             props.theme.font.size[minimizeFont[props.textSize]]};
     }

--- a/src/lib/Topbar/style/index.js
+++ b/src/lib/Topbar/style/index.js
@@ -7,8 +7,8 @@ const TopbarBase = styled.header`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: solid ${props => props.theme.line}
-        ${props => props.theme.wab.grey10};
+    border-bottom: solid
+        ${props => props.theme.line + ' ' + props.theme.wab.grey10};
     background-color: ${props => props.theme.wab.white20};
 `;
 

--- a/src/shared/global.js
+++ b/src/shared/global.js
@@ -66,31 +66,31 @@ export const GlobalStyle = createGlobalStyle`
     }
 
     .hideOnMobile {
-        @media (${ThemeDefault.query.max.sm}) {
+        @media ${ThemeDefault.screen.max.sm} {
             display: none !important;
         }
     }
 
     .hideOnTablet {
-        @media (${ThemeDefault.query.max.md}) {
+        @media ${ThemeDefault.screen.max.md} {
             display: none !important;
         }
     }
 
     .hideOnDesktop {
-        @media (${ThemeDefault.query.min.md}) {
+        @media ${ThemeDefault.screen.min.md} {
             display: none !important;
         }
     }
 
     .hideOnSmallScreen {
-        @media (${ThemeDefault.query.max.lg}) {
+        @media ${ThemeDefault.screen.max.lg} {
             display: none !important;
         }
     }
 
     .hideOnBigScreen {
-        @media (${ThemeDefault.query.min.lg}) {
+        @media ${ThemeDefault.screen.min.lg} {
             display: none !important;
         }
     }

--- a/src/shared/spaces.js
+++ b/src/shared/spaces.js
@@ -148,7 +148,7 @@ const responsiveSpaces = (
             getSpace('sm', 'Left', toRemove, bottomCoeff, topCoeff, directions),
         )};
 
-        @media (${props => props.theme.query.min.md}) {
+        @media ${props => props.theme.screen.min.md} {
             ${directionalProperty(
                 propAttribute,
                 getSpace(

--- a/src/theme/theme.base.js
+++ b/src/theme/theme.base.js
@@ -1,4 +1,4 @@
-const responsive = {
+const breakpoints = {
     sm: 550,
     md: 960,
     lg: 1200,
@@ -8,7 +8,7 @@ const responsive = {
 // Old way (for retro-compatibility)
 
 const query = (value, operator) => {
-    if (operator == 'max') {
+    if (operator === 'max') {
         value -= 0.01;
     }
     return operator + '-width: ' + value + 'px';
@@ -25,6 +25,21 @@ const screen = (value, isMax = false) => {
         return base;
     }
 };
+
+const queries = {
+    min: {},
+    max: {},
+};
+
+const screens = queries;
+
+for (const [size, value] of Object.entries(breakpoints)) {
+    queries.min[size] = query(value, 'min');
+    queries.max[size] = query(value, 'max');
+
+    screens.min[size] = screen(value);
+    screens.max[size] = screen(value, true);
+}
 
 const pallet = {
     green: {
@@ -308,34 +323,9 @@ export const ThemeBase = {
         popin: 115,
         modal: 120,
     },
-    query: {
-        min: {
-            sm: query(responsive.sm, 'min'),
-            md: query(responsive.md, 'min'),
-            lg: query(responsive.lg, 'min'),
-            xl: query(responsive.xl, 'min'),
-        },
-        max: {
-            sm: query(responsive.sm, 'max'),
-            md: query(responsive.md, 'max'),
-            lg: query(responsive.lg, 'max'),
-            xl: query(responsive.xl, 'max'),
-        },
-    },
-    screen: {
-        min: {
-            sm: screen(responsive.sm),
-            md: screen(responsive.md),
-            lg: screen(responsive.lg),
-            xl: screen(responsive.xl),
-        },
-        max: {
-            sm: screen(responsive.sm, true),
-            md: screen(responsive.md, true),
-            lg: screen(responsive.lg, true),
-            xl: screen(responsive.xl, true),
-        },
-    }, 
+    query: queries,
+    screen: screens,
+    breakpoint: breakpoints,
     button: {
         paddingWidth: {
             sm: '22px',

--- a/src/theme/theme.base.js
+++ b/src/theme/theme.base.js
@@ -5,11 +5,25 @@ const responsive = {
     xl: 1360,
 };
 
+// Old way (for retro-compatibility)
+
 const query = (value, operator) => {
     if (operator == 'max') {
-        value -= 1;
+        value -= 0.01;
     }
     return operator + '-width: ' + value + 'px';
+};
+
+// New way
+
+const screen = (value, isMax = false) => {
+    const base = '(min-width: ' + value + 'px)';
+
+    if (isMax) {
+        return 'not all and ' + base;
+    } else {
+        return base;
+    }
 };
 
 const pallet = {
@@ -308,6 +322,20 @@ export const ThemeBase = {
             xl: query(responsive.xl, 'max'),
         },
     },
+    screen: {
+        min: {
+            sm: screen(responsive.sm),
+            md: screen(responsive.md),
+            lg: screen(responsive.lg),
+            xl: screen(responsive.xl),
+        },
+        max: {
+            sm: screen(responsive.sm, true),
+            md: screen(responsive.md, true),
+            lg: screen(responsive.lg, true),
+            xl: screen(responsive.xl, true),
+        },
+    }, 
     button: {
         paddingWidth: {
             sm: '22px',

--- a/src/theme/theme.base.js
+++ b/src/theme/theme.base.js
@@ -18,12 +18,7 @@ const query = (value, operator) => {
 
 const screen = (value, isMax = false) => {
     const base = '(min-width: ' + value + 'px)';
-
-    if (isMax) {
-        return 'not all and ' + base;
-    } else {
-        return base;
-    }
+    return isMax ? 'not all and ' + base : base;
 };
 
 const queries = {
@@ -31,7 +26,10 @@ const queries = {
     max: {},
 };
 
-const screens = queries;
+const screens = {
+    min: {},
+    max: {},
+};
 
 for (const [size, value] of Object.entries(breakpoints)) {
     queries.min[size] = query(value, 'min');


### PR DESCRIPTION
Le bug à résoudre, c'était cet affichage : 

![image](https://user-images.githubusercontent.com/32125579/100083987-7cbab300-2e4a-11eb-979f-0017d052dfb0.png)

Qui ne se produisait que sur un pixel bien particulier (le 1199px de large, soit la `query.lg`). Pour une raison qui ne regarde que mon écran HD, je devais réussir à générer un affichage un peu bâtard (un 1199.999999px, sûrement !), ce qui empêchait les media queries existantes de faire leur travail (aucune ne se sentait concernée par cet affichage-là, donc le taf était pas fait - bande de feignasses).

- Fix : update du jeu de media queries pour utiliser `value - 0.01` au lieu de `value - 1` (exemple : 1199.99px au lieu de 1199px). Cela ne règle pas tous les bugs sur les valeurs charnières, mais ça en résout beaucoup 🎉 
- Fix : utilisation du `not` dans un nouveau jeu de media queries au lieu de `value - 0.01` (et ça, ça résout absolument tous les bugs !). 🍾 
- Fix : utilisation du nouveau jeu de media queries (les `screen`) dans tous les composants de la librairie ✔️ (notez que là où les anciennes media queries ont été intégrées, ça marchera toujours, c'est rétro-compatible - mais vous devriez songer à MAJ pour être tranquille et éviter le bug du 1199.99 px)
- Feat : ajout de la liste des breakpoints (en type `int`) utilisés pour les media queries dans le theme : c'est Fanny qui va être contente de pouvoir retirer les tricks qu'elle a dû faire pour obtenir ces valeurs pour ses hooks ! 💪 
- Style : petit coup de prettier sur certains fichiers où je suis passée
