### PR TITLE
PGF-587: add overflowEmphasis option for Table

### DIFF
--- a/src/lib/Table/Table.js
+++ b/src/lib/Table/Table.js
@@ -14,12 +14,14 @@ const Table = props => {
 Table.propTypes = {
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
     hasLargeFirstColumn: PropTypes.bool,
+    hasOverflowEmphasis: PropTypes.bool,
     hasBackground: PropTypes.bool,
 };
 
 Table.defaultProps = {
     colorTheme: colorThemeDefault,
     hasLargeFirstColumn: true,
+    hasOverflowEmphasis: false,
     hasBackground: false,
 };
 

--- a/src/lib/Table/Table.stories.js
+++ b/src/lib/Table/Table.stories.js
@@ -7,6 +7,7 @@ import {
     colorThemeDefault,
 } from '../../shared/constants';
 import Link from '../Link/Link';
+import Grid from '../Grid/Grid';
 import TableCell from '../TableCell/TableCell';
 import TableRow from '../TableRow/TableRow';
 import Table from './Table';
@@ -14,58 +15,65 @@ import Table from './Table';
 storiesOf(folder.table + folder.sub.table + 'Table', module)
     .addDecorator(withKnobs)
     .add('Table', () => (
-        <Table
-            colorTheme={radios('Color', colorThemeOptions, colorThemeDefault)}
-            hasLargeFirstColumn={boolean('Large first column', true)}
-            hasBackground={boolean('Has background', false)}
-        >
-            <TableRow isMain={true}>
-                <TableCell>Table name</TableCell>
+        <Grid childrenFlex={1}>
+            <Table
+                colorTheme={radios(
+                    'Color',
+                    colorThemeOptions,
+                    colorThemeDefault,
+                )}
+                hasLargeFirstColumn={boolean('Large first column', true)}
+                hasOverflowEmphasis={boolean('Has overflow emphasis', false)}
+                hasBackground={boolean('Has background', false)}
+            >
+                <TableRow isMain={true}>
+                    <TableCell>Table name</TableCell>
 
-                <TableCell>
-                    <span>Column one</span>
+                    <TableCell>
+                        <span>Column one</span>
 
-                    <i>
-                        Short description of this column (not{' '}
-                        <strong>too long</strong>).
-                    </i>
-                </TableCell>
+                        <i>
+                            Short description of this column (not{' '}
+                            <strong>too long</strong>).
+                        </i>
+                    </TableCell>
 
-                <TableCell>
-                    <span>Column two</span>
+                    <TableCell>
+                        <span>Column two</span>
 
-                    <i>Another short description.</i>
-                </TableCell>
-            </TableRow>
+                        <i>Another short description.</i>
+                    </TableCell>
+                </TableRow>
 
-            <TableRow>
-                <TableCell>Row name</TableCell>
+                <TableRow>
+                    <TableCell>Row name</TableCell>
 
-                <TableCell>11,90&nbsp;€</TableCell>
+                    <TableCell>11,90&nbsp;€</TableCell>
 
-                <TableCell>
-                    9,90&nbsp;€<strong>*</strong>
-                </TableCell>
-            </TableRow>
+                    <TableCell>
+                        9,90&nbsp;€<strong>*</strong>
+                    </TableCell>
+                </TableRow>
 
-            <TableRow colorTheme={colorThemeOptions.tertiary}>
-                <TableCell>
-                    <span>
-                        Row name <i>(with some precisions)</i>
-                    </span>
-                </TableCell>
+                <TableRow colorTheme={colorThemeOptions.tertiary}>
+                    <TableCell>
+                        <span>
+                            Row name <i>(with some precisions)</i>
+                        </span>
+                    </TableCell>
 
-                <TableCell>
-                    <a href="#">
-                        <Link colorTheme={colorThemeOptions.tertiary}>
-                            Contact us
-                        </Link>
-                    </a>
-                </TableCell>
+                    <TableCell>
+                        <a href="#">
+                            <Link colorTheme={colorThemeOptions.tertiary}>
+                                Contact us
+                            </Link>
+                        </a>
+                    </TableCell>
 
-                <TableCell>
-                    9,90&nbsp;€<strong>*</strong>
-                </TableCell>
-            </TableRow>
-        </Table>
+                    <TableCell>
+                        9,90&nbsp;€<strong>*</strong>
+                    </TableCell>
+                </TableRow>
+            </Table>
+        </Grid>
     ));

--- a/src/lib/Table/__snapshots__/Table.test.js.snap
+++ b/src/lib/Table/__snapshots__/Table.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__TableBase-zyowmo-0 bSvOKQ"
+  className="style__TableBase-zyowmo-0 ezzDLP"
 >
   <div
     className="table"

--- a/src/lib/Table/style/base.js
+++ b/src/lib/Table/style/base.js
@@ -20,6 +20,24 @@ const largeFirstColumnStyle = css`
     }
 `;
 
+const overflowEmphasisStyle = css`
+    @media ${props => props.theme.screen.max.md} {
+        margin-left: -${props => props.theme.space.md} !important;
+        margin-right: -${props => props.theme.space.md} !important;
+        mask-image: linear-gradient(
+            to left,
+            transparent,
+            black ${props => props.theme.space.md}
+        );
+    }
+
+    .table {
+        @media ${props => props.theme.screen.max.md} {
+            padding: 0 ${props => props.theme.space.md};
+        }
+    }
+`;
+
 const backgroundStyle = css`
     background-color: ${props => props.theme.wab.white00};
     border-radius: ${props => props.theme.radius.lg};
@@ -38,4 +56,4 @@ const backgroundStyle = css`
     }
 `;
 
-export { largeFirstColumnStyle, backgroundStyle };
+export { largeFirstColumnStyle, overflowEmphasisStyle, backgroundStyle };

--- a/src/lib/Table/style/index.js
+++ b/src/lib/Table/style/index.js
@@ -1,21 +1,17 @@
 import styled from 'styled-components';
 import { transparentize } from 'polished';
-import { largeFirstColumnStyle, backgroundStyle } from './base';
 import { TableCellBase } from '../../TableCell/style';
 import { TableRowBase } from '../../TableRow/style';
+import {
+    largeFirstColumnStyle,
+    overflowEmphasisStyle,
+    backgroundStyle,
+} from './base';
 
 const TableBase = styled.div`
     position: relative;
     overflow-x: auto;
     ${props => (props.hasBackground ? backgroundStyle : null)};
-
-    @media ${props => props.theme.screen.max.sm} {
-        mask-image: linear-gradient(
-            to left,
-            transparent,
-            black ${props => props.theme.space.lg}
-        );
-    }
 
     .table {
         display: table;
@@ -39,6 +35,7 @@ const TableBase = styled.div`
     }
 
     ${props => (props.hasLargeFirstColumn ? largeFirstColumnStyle : null)};
+    ${props => (props.hasOverflowEmphasis ? overflowEmphasisStyle : null)};
 `;
 
 export { TableBase };


### PR DESCRIPTION
Ajout d'une option `hasOverflowEmphasis` pour les composants **Table** : elle permet de dégrader l'overflow des tableaux sur petit écran et plus simplement de tronquer de manière nette, afin de mieux indiquer que le tableau s'étend vers la droite.