### PR TITLE
PGF-666: Added hook to detect outside click and close dropdown component

### DIFF
--- a/src/lib/Dropdown/Dropdown.js
+++ b/src/lib/Dropdown/Dropdown.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import DaInput from '../DaInput/DaInput';
 import Popin from '../Popin/Popin';
@@ -8,39 +8,75 @@ import { DropdownBase, InvisibleCloseButton } from './style';
 const Dropdown = ({ children, hasOverlay, ...rest }) => {
     const [isOpen, setOpen] = useState();
 
+    /**
+     * Hook that detects when we click outside of the passed ref and when dropdown is opened and without overlay
+     * @param {object} ref - reference used to detect click outside
+     */
+    const useOutsideAlerter = ref => {
+        useEffect(() => {
+            const handleClickOutside = e => {
+                if (
+                    isOpen &&
+                    !hasOverlay &&
+                    ref.current &&
+                    !ref.current.contains(e.target)
+                ) {
+                    setOpen(false);
+                }
+            };
+
+            // Bind the event listener
+            document.addEventListener('mousedown', handleClickOutside);
+
+            return () => {
+                // Unbind the event listener on clean up
+                document.removeEventListener('mousedown', handleClickOutside);
+            };
+        }, [ref, isOpen, hasOverlay]);
+    };
+
+    // We create the reference linked to Dropdown component and pass it to the hook
+    const dropdownRef = useRef(null);
+    useOutsideAlerter(dropdownRef);
+
     return (
         <DropdownContext.Provider value={{ isOpen, setOpen }}>
-            <DropdownBase {...rest}>
-                {isOpen && hasOverlay ? (
-                    <InvisibleCloseButton onClick={() => setOpen(!isOpen)} />
-                ) : null}
+            {/*ref can only be applied on DOM element and not on react component directly*/}
+            <span ref={dropdownRef}>
+                <DropdownBase {...rest}>
+                    {isOpen && hasOverlay ? (
+                        <InvisibleCloseButton
+                            onClick={() => setOpen(!isOpen)}
+                        />
+                    ) : null}
 
-                {React.Children.map(children, (child, index) => {
-                    switch (child && child.type) {
-                        case null:
-                            return null;
+                    {React.Children.map(children, (child, index) => {
+                        switch (child && child.type) {
+                            case null:
+                                return null;
 
-                        case DaInput:
-                            return React.cloneElement(child, {
-                                onClick: () => setOpen(!isOpen),
-                                key: index,
-                            });
+                            case DaInput:
+                                return React.cloneElement(child, {
+                                    onClick: () => setOpen(!isOpen),
+                                    key: index,
+                                });
 
-                        case Popin:
-                            return React.cloneElement(child, {
-                                isActive: isOpen,
-                                key: index,
-                            });
+                            case Popin:
+                                return React.cloneElement(child, {
+                                    isActive: isOpen,
+                                    key: index,
+                                });
 
-                        default:
-                            return React.cloneElement(child, {
-                                onClick: () => setOpen(!isOpen),
-                                isActive: isOpen,
-                                key: index,
-                            });
-                    }
-                })}
-            </DropdownBase>
+                            default:
+                                return React.cloneElement(child, {
+                                    onClick: () => setOpen(!isOpen),
+                                    isActive: isOpen,
+                                    key: index,
+                                });
+                        }
+                    })}
+                </DropdownBase>
+            </span>
         </DropdownContext.Provider>
     );
 };


### PR DESCRIPTION
## Ce qui a été fait : 
- ajout d'un hook pour fermer le dropdown quand on clique à l'extérieur s'il n'y a pas d'overlay

## Comment tester : 
- dans la story du dropdown, "dropdown with clickable block" : 
       - si hasOverlay est true :  au clic à l'extérieur le dropdown se ferme
       - si hasOverlay est false : au clic à l'extérieur ça se ferme aussi :)     
       
@OliviaGometz je ne voulais pas compliquer la story donc je n'ai rien rajouté d'autre mais j'ai fait un test d'intégration dans le BO ClimateKit et ça marche :) 