### PR TITLE
PGF-709 : update de l'histogram et histogrambar

### DIFF
--- a/src/lib/Histogram/Histogram.js
+++ b/src/lib/Histogram/Histogram.js
@@ -14,6 +14,7 @@ const Histogram = ({
     maxValue,
     hasYaxisMin,
     hasYaxisMax,
+    yaxisMaxValueLabel,
     yaxisValues,
     yaxisUnit,
     isRelativeYaxis,
@@ -36,6 +37,7 @@ const Histogram = ({
             <YAxis
                 theme={rest.theme} // not necessary, only needed for tests
                 maxValue={max}
+                maxValueLabel={yaxisMaxValueLabel}
                 values={yaxisValues}
                 hasMin={hasYaxisMin}
                 hasMax={hasYaxisMax}
@@ -69,6 +71,7 @@ Histogram.propTypes = {
     hasYaxisMax: PropTypes.bool,
     yaxisValues: PropTypes.arrayOf(PropTypes.number),
     yaxisUnit: PropTypes.string,
+    yaxisMaxValueLabel: PropTypes.number,
     maxValue: PropTypes.number,
     blockHeight: PropTypes.oneOf(Object.values(inputWidthOptions)),
     marginTop: PropTypes.oneOf(Object.values(spaceOptions)),
@@ -81,6 +84,7 @@ Histogram.defaultProps = {
     hasYaxisMax: true,
     yaxisValues: [],
     yaxisUnit: null,
+    yaxisMaxValueLabel: null,
     maxValue: 0,
     blockHeight: inputWidthDefault,
     marginTop: spaceDefault,

--- a/src/lib/Histogram/Histogram.js
+++ b/src/lib/Histogram/Histogram.js
@@ -14,7 +14,7 @@ const Histogram = ({
     maxValue,
     hasYaxisMin,
     hasYaxisMax,
-    yaxisMaxValueDisplay,
+    yaxisMaxValue,
     yaxisValues,
     yaxisUnit,
     isRelativeYaxis,
@@ -36,8 +36,7 @@ const Histogram = ({
         <HistogramBase {...rest}>
             <YAxis
                 theme={rest.theme} // not necessary, only needed for tests
-                maxValue={max}
-                maxValueDisplay={yaxisMaxValueDisplay}
+                maxValue={yaxisMaxValue || max}
                 values={yaxisValues}
                 hasMin={hasYaxisMin}
                 hasMax={hasYaxisMax}
@@ -71,7 +70,7 @@ Histogram.propTypes = {
     hasYaxisMax: PropTypes.bool,
     yaxisValues: PropTypes.arrayOf(PropTypes.number),
     yaxisUnit: PropTypes.string,
-    yaxisMaxValueDisplay: PropTypes.number,
+    yaxisMaxValue: PropTypes.number,
     maxValue: PropTypes.number,
     blockHeight: PropTypes.oneOf(Object.values(inputWidthOptions)),
     marginTop: PropTypes.oneOf(Object.values(spaceOptions)),
@@ -84,7 +83,7 @@ Histogram.defaultProps = {
     hasYaxisMax: true,
     yaxisValues: [],
     yaxisUnit: null,
-    yaxisMaxValueDisplay: null,
+    yaxisMaxValue: null,
     maxValue: 0,
     blockHeight: inputWidthDefault,
     marginTop: spaceDefault,

--- a/src/lib/Histogram/Histogram.js
+++ b/src/lib/Histogram/Histogram.js
@@ -14,7 +14,7 @@ const Histogram = ({
     maxValue,
     hasYaxisMin,
     hasYaxisMax,
-    yaxisMaxValueLabel,
+    yaxisMaxValueDisplay,
     yaxisValues,
     yaxisUnit,
     isRelativeYaxis,
@@ -37,7 +37,7 @@ const Histogram = ({
             <YAxis
                 theme={rest.theme} // not necessary, only needed for tests
                 maxValue={max}
-                maxValueLabel={yaxisMaxValueLabel}
+                maxValueDisplay={yaxisMaxValueDisplay}
                 values={yaxisValues}
                 hasMin={hasYaxisMin}
                 hasMax={hasYaxisMax}
@@ -71,7 +71,7 @@ Histogram.propTypes = {
     hasYaxisMax: PropTypes.bool,
     yaxisValues: PropTypes.arrayOf(PropTypes.number),
     yaxisUnit: PropTypes.string,
-    yaxisMaxValueLabel: PropTypes.number,
+    yaxisMaxValueDisplay: PropTypes.number,
     maxValue: PropTypes.number,
     blockHeight: PropTypes.oneOf(Object.values(inputWidthOptions)),
     marginTop: PropTypes.oneOf(Object.values(spaceOptions)),
@@ -84,7 +84,7 @@ Histogram.defaultProps = {
     hasYaxisMax: true,
     yaxisValues: [],
     yaxisUnit: null,
-    yaxisMaxValueLabel: null,
+    yaxisMaxValueDisplay: null,
     maxValue: 0,
     blockHeight: inputWidthDefault,
     marginTop: spaceDefault,

--- a/src/lib/Histogram/Histogram.stories.js
+++ b/src/lib/Histogram/Histogram.stories.js
@@ -93,7 +93,7 @@ storiesOf(folder.graph + 'Histogram', module)
                     key={index}
                     value={sample.value}
                     label={sample.label}
-                    legend="{value}€ in {label}"
+                    legend={sample.value + ' € in ' + sample.label}
                     isLabelVisible={false}
                     colorTheme={sample.colorTheme}
                     blockWidth={sample.blockWidth}

--- a/src/lib/Histogram/YAxis/YAxis.js
+++ b/src/lib/Histogram/YAxis/YAxis.js
@@ -7,11 +7,13 @@ import {
     greyOptions,
     textHtmlTagOptions,
 } from '../../../shared/constants';
+import { adjustDecimalNumber } from '../../../shared/tools';
 import Text from '../../Text/Text';
 import { YAxisBase, YAxisElementBase } from './style';
 
 const YAxis = ({
     maxValue,
+    maxValueLabel,
     values,
     hasMin,
     hasMax,
@@ -23,17 +25,18 @@ const YAxis = ({
 
     allValues.push(0);
 
+    // if maxValueLabel is provided (due to specific conversion) we use it to build yAxis else we use global maxValue
     values.map(value => {
         if (value > 0) {
             if (isRelative && value < 100) {
-                allValues.push((value * maxValue) / 100);
-            } else if (value < maxValue) {
+                allValues.push((value * (maxValueLabel || maxValue)) / 100);
+            } else if (value < (maxValueLabel || maxValue)) {
                 allValues.push(value);
             }
         }
     });
 
-    allValues.push(maxValue);
+    allValues.push(maxValueLabel || maxValue);
 
     allValues = Array.from(new Set(allValues)); // remove duplicated values
     allValues = allValues.sort((a, b) => b - a); // desc sort
@@ -68,8 +71,7 @@ const YAxis = ({
                             textSize={fontSizeOptions.xxs}
                             colorWab={greyOptions.grey40}
                         >
-                            {Math.round(value)}
-                            {unit}
+                            {adjustDecimalNumber(value)}&nbsp;{unit}
                         </Text>
                     </YAxisElementBase>
                 ) : (

--- a/src/lib/Histogram/YAxis/YAxis.js
+++ b/src/lib/Histogram/YAxis/YAxis.js
@@ -13,7 +13,7 @@ import { YAxisBase, YAxisElementBase } from './style';
 
 const YAxis = ({
     maxValue,
-    maxValueLabel,
+    maxValueDisplay,
     values,
     hasMin,
     hasMax,
@@ -25,18 +25,18 @@ const YAxis = ({
 
     allValues.push(0);
 
-    // if maxValueLabel is provided (due to specific conversion) we use it to build yAxis else we use global maxValue
+    // if maxValueDisplay is provided (due to specific conversion) we use it to build yAxis else we use global maxValue
     values.map(value => {
         if (value > 0) {
             if (isRelative && value < 100) {
-                allValues.push((value * (maxValueLabel || maxValue)) / 100);
-            } else if (value < (maxValueLabel || maxValue)) {
+                allValues.push((value * (maxValueDisplay || maxValue)) / 100);
+            } else if (value < (maxValueDisplay || maxValue)) {
                 allValues.push(value);
             }
         }
     });
 
-    allValues.push(maxValueLabel || maxValue);
+    allValues.push(maxValueDisplay || maxValue);
 
     allValues = Array.from(new Set(allValues)); // remove duplicated values
     allValues = allValues.sort((a, b) => b - a); // desc sort
@@ -84,6 +84,7 @@ const YAxis = ({
 
 YAxis.propTypes = {
     maxValue: PropTypes.number.isRequired,
+    maxValueDisplay: PropTypes.number,
     values: PropTypes.arrayOf(PropTypes.number),
     isRelative: PropTypes.bool,
     hasMin: PropTypes.bool,
@@ -93,6 +94,7 @@ YAxis.propTypes = {
 };
 
 YAxis.defaultProps = {
+    maxValueDisplay: null,
     values: [],
     isRelative: false,
     hasMin: true,

--- a/src/lib/Histogram/YAxis/YAxis.js
+++ b/src/lib/Histogram/YAxis/YAxis.js
@@ -13,7 +13,6 @@ import { YAxisBase, YAxisElementBase } from './style';
 
 const YAxis = ({
     maxValue,
-    maxValueDisplay,
     values,
     hasMin,
     hasMax,
@@ -25,18 +24,17 @@ const YAxis = ({
 
     allValues.push(0);
 
-    // if maxValueDisplay is provided (due to specific conversion) we use it to build yAxis else we use global maxValue
     values.map(value => {
         if (value > 0) {
             if (isRelative && value < 100) {
-                allValues.push((value * (maxValueDisplay || maxValue)) / 100);
-            } else if (value < (maxValueDisplay || maxValue)) {
+                allValues.push((value * maxValue) / 100);
+            } else if (value < maxValue) {
                 allValues.push(value);
             }
         }
     });
 
-    allValues.push(maxValueDisplay || maxValue);
+    allValues.push(maxValue);
 
     allValues = Array.from(new Set(allValues)); // remove duplicated values
     allValues = allValues.sort((a, b) => b - a); // desc sort
@@ -84,7 +82,6 @@ const YAxis = ({
 
 YAxis.propTypes = {
     maxValue: PropTypes.number.isRequired,
-    maxValueDisplay: PropTypes.number,
     values: PropTypes.arrayOf(PropTypes.number),
     isRelative: PropTypes.bool,
     hasMin: PropTypes.bool,
@@ -94,7 +91,6 @@ YAxis.propTypes = {
 };
 
 YAxis.defaultProps = {
-    maxValueDisplay: null,
     values: [],
     isRelative: false,
     hasMin: true,

--- a/src/lib/Histogram/YAxis/YAxis.test.js
+++ b/src/lib/Histogram/YAxis/YAxis.test.js
@@ -5,7 +5,12 @@ import YAxis from './YAxis';
 
 it('renders without crashing', () => {
     const component = TestRenderer.create(
-        <YAxis theme={ThemeDefault} values={[34.5, 64, 107]} maxValue={123} />,
+        <YAxis
+            theme={ThemeDefault}
+            values={[34.5, 64, 107]}
+            unit="€"
+            maxValue={123}
+        />,
     );
     expect(component.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
+++ b/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
@@ -11,6 +11,7 @@ exports[`renders without crashing 1`] = `
       className="style__TextBase-sc-11ixwvd-0 jhNWiV"
     >
       123
+       
     </span>
   </div>
   <div
@@ -20,6 +21,7 @@ exports[`renders without crashing 1`] = `
       className="style__TextBase-sc-11ixwvd-0 jhNWiV"
     >
       107
+       
     </span>
   </div>
   <div
@@ -29,6 +31,7 @@ exports[`renders without crashing 1`] = `
       className="style__TextBase-sc-11ixwvd-0 jhNWiV"
     >
       64
+       
     </span>
   </div>
   <div
@@ -37,7 +40,8 @@ exports[`renders without crashing 1`] = `
     <span
       className="style__TextBase-sc-11ixwvd-0 jhNWiV"
     >
-      35
+      34.5
+       
     </span>
   </div>
   <div
@@ -47,6 +51,7 @@ exports[`renders without crashing 1`] = `
       className="style__TextBase-sc-11ixwvd-0 jhNWiV"
     >
       0
+       
     </span>
   </div>
 </div>

--- a/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
+++ b/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders without crashing 1`] = `
     >
       123
        
+      €
     </span>
   </div>
   <div
@@ -22,6 +23,7 @@ exports[`renders without crashing 1`] = `
     >
       107
        
+      €
     </span>
   </div>
   <div
@@ -32,6 +34,7 @@ exports[`renders without crashing 1`] = `
     >
       64
        
+      €
     </span>
   </div>
   <div
@@ -42,6 +45,7 @@ exports[`renders without crashing 1`] = `
     >
       34.5
        
+      €
     </span>
   </div>
   <div
@@ -52,6 +56,7 @@ exports[`renders without crashing 1`] = `
     >
       0
        
+      €
     </span>
   </div>
 </div>

--- a/src/lib/Histogram/__snapshots__/Histogram.test.js.snap
+++ b/src/lib/Histogram/__snapshots__/Histogram.test.js.snap
@@ -14,6 +14,7 @@ exports[`renders without crashing 1`] = `
         className="style__TextBase-sc-11ixwvd-0 jhNWiV"
       >
         110
+         
       </span>
     </div>
     <div
@@ -23,6 +24,7 @@ exports[`renders without crashing 1`] = `
         className="style__TextBase-sc-11ixwvd-0 jhNWiV"
       >
         0
+         
       </span>
     </div>
   </div>

--- a/src/lib/HistogramBar/HistogramBar.js
+++ b/src/lib/HistogramBar/HistogramBar.js
@@ -47,9 +47,7 @@ const HistogramBar = ({ value, maxValue, label, legend, ...rest }) => {
                         textSize={fontSizeOptions.xxs}
                         align={alignItemsOptions.center}
                     >
-                        {legend
-                            .replace('{value}', value)
-                            .replace('{label}', label)}
+                        {legend}
                     </Text>
                 </Message>
             ) : null}
@@ -73,7 +71,7 @@ HistogramBar.propTypes = {
     maxValue: PropTypes.number,
     isLabelVisible: PropTypes.bool,
     label: PropTypes.string,
-    legend: PropTypes.string,
+    legend: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
     blockHeight: PropTypes.oneOf(Object.values(inputWidthOptions)),
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),

--- a/src/lib/HistogramBar/HistogramBar.stories.js
+++ b/src/lib/HistogramBar/HistogramBar.stories.js
@@ -18,35 +18,47 @@ import HistogramBar from './HistogramBar';
 
 storiesOf(folder.graph + 'HistogramBar', module)
     .addDecorator(withKnobs)
-    .add('HistogramBar', () => (
-        <HistogramBar
-            style={{ margin: '0 auto' }} // only for complete display in story
-            label={text('Label', 'September')}
-            isLabelVisible={boolean('Is label visible', true)}
-            legend={text('Legend', '{value}% in {label}')}
-            value={number('Value', 60, {
-                range: true,
-                max: 100,
-            })}
-            colorTheme={select(
-                'Color theme',
-                colorThemeOptions,
-                colorThemeDefault,
-            )}
-            blockHeight={select(
-                'Block height',
-                inputWidthOptions,
-                inputWidthOptions.sm,
-            )}
-            blockWidth={select(
-                'Block width',
-                inputWidthOptions,
-                inputWidthOptions.xs,
-            )}
-            paddingLateral={select(
-                'Lateral padding',
-                spaceOptions,
-                spaceOptions.sm,
-            )}
-        />
-    ));
+    .add('HistogramBar', () => {
+        // Knobs as dynamic variables
+        const dynamicValue = number('Value', 60, {
+            range: true,
+            max: 100,
+        });
+        const dynamicLabel = text('Label', 'September');
+
+        return (
+            <HistogramBar
+                style={{ margin: '0 auto' }} // only for complete display in story
+                label={dynamicLabel}
+                isLabelVisible={boolean('Is label visible', true)}
+                value={dynamicValue}
+                legend={
+                    dynamicValue +
+                    ' ' +
+                    text('Legend', '% in') +
+                    ' ' +
+                    dynamicLabel
+                }
+                colorTheme={select(
+                    'Color theme',
+                    colorThemeOptions,
+                    colorThemeDefault,
+                )}
+                blockHeight={select(
+                    'Block height',
+                    inputWidthOptions,
+                    inputWidthOptions.sm,
+                )}
+                blockWidth={select(
+                    'Block width',
+                    inputWidthOptions,
+                    inputWidthOptions.xs,
+                )}
+                paddingLateral={select(
+                    'Lateral padding',
+                    spaceOptions,
+                    spaceOptions.sm,
+                )}
+            />
+        );
+    });

--- a/src/lib/HistogramBar/HistogramBar.test.js
+++ b/src/lib/HistogramBar/HistogramBar.test.js
@@ -4,12 +4,15 @@ import { ThemeDefault } from '../../theme';
 import HistogramBar from './HistogramBar';
 
 it('renders without crashing', () => {
+    const value = 60;
+    const label = 'label';
+
     const component = TestRenderer.create(
         <HistogramBar
             theme={ThemeDefault}
-            value={60}
-            label="label"
-            legend="{value} in {label}"
+            value={value}
+            label={label}
+            legend={value + ' in ' + label}
         />,
     );
     expect(component.toJSON()).toMatchSnapshot();

--- a/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
+++ b/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders without crashing 1`] = `
     <p
       className="style__TextBase-sc-11ixwvd-0 ePvKFZ"
     >
-      60 in label
+      {value} in {label}
     </p>
   </div>
   <div

--- a/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
+++ b/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders without crashing 1`] = `
     <p
       className="style__TextBase-sc-11ixwvd-0 ePvKFZ"
     >
-      {value} in {label}
+      60 in label
     </p>
   </div>
   <div

--- a/src/shared/tools.js
+++ b/src/shared/tools.js
@@ -1,0 +1,18 @@
+/**
+ * @description to adjust value length and limit up to 3 numbers
+ * @param {number} value
+ */
+const adjustDecimalNumber = value => {
+    switch (true) {
+        case !value:
+            return 0;
+        case value < 10:
+            return Number(value.toFixed(2));
+        case value < 100:
+            return Number(value.toFixed(1));
+        default:
+            return Number(value.toFixed(0));
+    }
+};
+
+export { adjustDecimalNumber };


### PR DESCRIPTION
## Ce qui a été fait : 
- suppression de l'arrondi sur le y axis
- ajout d'une méthode dans tools.js pour limiter le nombre de décimales dans les chiffres du y axis
- ajout d'une props "yaxisMaxValueLabel"  pour gérer la MaxValue (qui gère le calcul de l'ensemble des éléments) et la MaxValue "convertie" dans le y axis 
- dans histogramBar , enrichissement de la props " legend" pour éviter les warnings côté BO avec react i18next
- update des tests

## Comment tester :
- pas d'ajout de la props yaxisMaxValueLabel en stories car pas utile
- tester l'ensemble du comportement de Histogram et HistogramBar  dans storybook avec notamment les knobs en dynamique