### PR TITLE
PGF-699 : Char component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "browser": "build/index.js",
   "scripts": {
     "build": "rollup -c",
-    "storybook": "start-storybook",
+    "start": "start-storybook",
     "prepare": "npm run build",
     "test": "jest",
     "test-update": "jest --updateSnapshot",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@n8tb1t/use-scroll-position": "^1.0.47",
+    "caniuse-lite": "^1.0.30001214",
     "core-js": "^3.6.5",
     "moment": "^2.29.0",
     "polished": "^3.6.7",

--- a/src/lib/Char/Char.js
+++ b/src/lib/Char/Char.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import { charModeOptions, charModeDefault } from '../../shared/constants';
+
+const Char = ({
+    text,
+    mode,
+    truncateCharacter,
+    hideCharacter,
+    hideExclusions,
+    startLength,
+    endLength,
+}) => {
+    const startString = text.substring(0, startLength);
+    const endString = text.substring(text.length - endLength, text.length);
+
+    switch (mode) {
+        case charModeOptions.truncate:
+            // we don't truncate string if it's short enough
+            if (text.length > startLength + endLength + 1) {
+                return startString + truncateCharacter + endString;
+            }
+
+            return text;
+
+        case charModeOptions.hide:
+            if (text.length > startLength + endLength) {
+                const otherCharacters = text
+                    .substring(startLength, text.length - endLength)
+                    .split('');
+                let hiddenString = '';
+
+                // we check for every character if we must hide it or not (some character must be displayed, as space for example)
+                otherCharacters.forEach(char => {
+                    hiddenString += hideExclusions.includes(char)
+                        ? char
+                        : hideCharacter;
+                });
+
+                return startString + hiddenString + endString;
+            }
+
+            return text;
+
+        default:
+            return null;
+    }
+};
+
+Char.propTypes = {
+    text: PropTypes.string.isRequired,
+    mode: PropTypes.oneOf(Object.values(charModeOptions)),
+    truncateCharacter: PropTypes.string,
+    hideCharacter: PropTypes.string,
+    hideExclusions: PropTypes.array,
+    startLength: PropTypes.number,
+    endLength: PropTypes.number,
+};
+
+Char.defaultProps = {
+    mode: charModeDefault,
+    truncateCharacter: '...',
+    hideCharacter: '*',
+    hideExclusions: [' '],
+    startLength: 3,
+    endLength: 3,
+};
+
+export default Char;

--- a/src/lib/Char/Char.stories.js
+++ b/src/lib/Char/Char.stories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text, radios, number } from '@storybook/addon-knobs';
+import {
+    folder,
+    charModeOptions,
+    charModeDefault,
+} from '../../shared/constants';
+import Char from './Char';
+
+storiesOf(folder.text + 'Char', module)
+    .addDecorator(withKnobs)
+    .add('Char', () => (
+        <Char
+            text={text('Text', '0123 4567 89 ABC')}
+            mode={radios('Mode', charModeOptions, charModeDefault)}
+            truncateCharacter={text('Truncate character', '...')}
+            hideCharacter={text('Hide character', '*')}
+            hideExclusions={[text('Hide exclusion (only one here)', ' ')]}
+            startLength={number('Start length', 3)}
+            endLength={number('End length', 3)}
+        />
+    ));

--- a/src/lib/Char/Char.test.js
+++ b/src/lib/Char/Char.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { ThemeDefault } from '../../theme';
+import Char from './Char';
+
+it('renders without crashing', () => {
+    const component = TestRenderer.create(
+        <Char theme={ThemeDefault} text="0123456789ABC" />,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+});

--- a/src/lib/Char/__snapshots__/Char.test.js.snap
+++ b/src/lib/Char/__snapshots__/Char.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `"012...ABC"`;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ import Breadcrumb from './Breadcrumb/Breadcrumb';
 import Button from './Button/Button';
 import ButtonGroup from './ButtonGroup/ButtonGroup';
 import Card from './Card/Card';
+import Char from './Char/Char';
 import Checkbox from './Checkbox/Checkbox';
 import CheckboxGroup from './CheckboxGroup/CheckboxGroup';
 import ClickableBlock from './ClickableBlock/ClickableBlock';
@@ -217,6 +218,7 @@ export {
     Button,
     ButtonGroup,
     Card,
+    Char,
     Checkbox,
     CheckboxGroup,
     ClickableBlock,

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -496,6 +496,14 @@ const localeOptions = {
 
 const localeDefault = localeOptions.fr;
 
+// Other
+const charModeOptions = {
+    truncate: 'truncate',
+    hide: 'hide',
+};
+
+const charModeDefault = charModeOptions.truncate;
+
 export {
     folder,
     debounceTime,
@@ -591,4 +599,6 @@ export {
     rotateSizeDefault,
     localeOptions,
     localeDefault,
+    charModeOptions,
+    charModeDefault,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,10 +3770,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001144"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz#bca0fffde12f97e1127a351fec3bfc1971aa3b3d"
-  integrity sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==
+caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001214:
+  version "1.0.30001214"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz#70f153c78223515c6d37a9fde6cd69250da9d872"
+  integrity sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Création du composant Char, qui permet de faire plein de petits choses sympas sur des chaînes de caractères : 
- Tronquer quand c'est trop long
- Masquer certains caractères pour les données sensibles

Plein de choses sont paramétrables : caractères à afficher au début et à la fin de la chaîne, caractères qui restent "en clair" même s'ils sont dans la zone à masquer (exemple : les espaces dans des IBAN, même si on masque les numéros, on peut avoir envie de garder les espaces sans les remplacer par des astérisques), caractères de remplacement (... pour les chaînes tronquées, * pour les chaînes masquées, et c'est donc paramétrable), etc.

Ce composant renvoie une string, c'est donc utilisable dans n'importe quel parent sans aucun impact sur le style.