### PR TITLE
PGF-773 : Fix sur les DaInput, DaSelect, DaTextarea pour avoir un width à 100%

### DIFF
--- a/src/lib/DaInput/DaInput.js
+++ b/src/lib/DaInput/DaInput.js
@@ -53,6 +53,7 @@ DaInput.propTypes = {
     isRounded: PropTypes.bool,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
+    hasStaticWidth: PropTypes.bool,
     hasHelpButton: PropTypes.bool,
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
@@ -67,6 +68,7 @@ DaInput.defaultProps = {
     isRounded: false,
     fieldSize: buttonSizeDefault,
     blockWidth: inputWidthDefault,
+    hasStaticWidth: false,
     hasHelpButton: false,
 };
 

--- a/src/lib/DaInput/DaInput.js
+++ b/src/lib/DaInput/DaInput.js
@@ -16,6 +16,7 @@ const DaInput = props => {
         fieldSize,
         blockWidth,
         hasHelpButton,
+        hasStaticWidth,
         // remove mask from rest
         mask,
         ...rest
@@ -39,6 +40,7 @@ const DaInput = props => {
             fieldSize={fieldSize}
             blockWidth={blockWidth}
             hasHelpButton={hasHelpButton}
+            hasStaticWidth={hasStaticWidth}
         >
             <InputMask {...rest} mask={stateMask} />
         </DaInputBase>

--- a/src/lib/DaInput/DaInput.stories.js
+++ b/src/lib/DaInput/DaInput.stories.js
@@ -28,6 +28,7 @@ storiesOf(folder.form + 'DaInput', module)
                 inputWidthOptions,
                 inputWidthDefault,
             )}
+            hasStaticWidth={boolean('Has static width', false)}
             hasHelpButton={boolean('Help button', false)}
         />
     ))

--- a/src/lib/DaInput/__snapshots__/DaInput.test.js.snap
+++ b/src/lib/DaInput/__snapshots__/DaInput.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaInputBase-sc-13xli4f-0 iDYsmg"
+  className="style__DaInputBase-sc-13xli4f-0 fIVBa-D"
 >
   <input
     disabled={false}

--- a/src/lib/DaInput/style/base.js
+++ b/src/lib/DaInput/style/base.js
@@ -65,4 +65,16 @@ const helpButtonStyle = css`
         )};
 `;
 
-export { field, disabled, enabled, helpButtonStyle };
+const widthStyle = {
+    fit: css`
+        max-width: ${props =>
+            props.inputType === 'tel'
+                ? props.theme.form.inputWidth.sm
+                : props.theme.form.inputWidth[props.blockWidth]};
+    `,
+    static: css`
+        width: 100%;
+    `,
+};
+
+export { field, disabled, enabled, helpButtonStyle, widthStyle };

--- a/src/lib/DaInput/style/base.js
+++ b/src/lib/DaInput/style/base.js
@@ -56,6 +56,7 @@ const helpButtonStyle = css`
     }
 
     width: ${props =>
+        !props.hasStaticWidth &&
         math(
             props.theme.form.inputWidth[
                 props.inputType === 'tel' ? 'sm' : props.blockWidth

--- a/src/lib/DaInput/style/index.js
+++ b/src/lib/DaInput/style/index.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { field, enabled, disabled, helpButtonStyle } from './base';
+import { field, enabled, disabled, helpButtonStyle, widthStyle } from './base';
 
 const DaInputBase = styled.div`
     input {
@@ -14,8 +14,8 @@ const DaInputBase = styled.div`
         }
     }
 
-    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
     ${props => (props.hasHelpButton ? helpButtonStyle : null)};
+    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
 `;
 
 export { DaInputBase };

--- a/src/lib/DaInput/style/index.js
+++ b/src/lib/DaInput/style/index.js
@@ -2,11 +2,6 @@ import styled from 'styled-components';
 import { field, enabled, disabled, helpButtonStyle } from './base';
 
 const DaInputBase = styled.div`
-    max-width: ${props =>
-        props.inputType === 'tel'
-            ? props.theme.form.inputWidth.sm
-            : props.theme.form.inputWidth[props.blockWidth]};
-
     input {
         ${field};
         line-height: ${props =>
@@ -19,6 +14,7 @@ const DaInputBase = styled.div`
         }
     }
 
+    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
     ${props => (props.hasHelpButton ? helpButtonStyle : null)};
 `;
 

--- a/src/lib/DaSelect/DaSelect.js
+++ b/src/lib/DaSelect/DaSelect.js
@@ -14,6 +14,7 @@ const DaSelect = props => {
         isRounded,
         fieldSize,
         blockWidth,
+        hasStaticWidth,
         hasHelpButton,
         // must not be passed with rest because there is no readOnly html attribute for select
         readOnly,
@@ -28,6 +29,7 @@ const DaSelect = props => {
             inputDisabled={props.disabled}
             isRounded={isRounded}
             blockWidth={blockWidth}
+            hasStaticWidth={hasStaticWidth}
             fieldSize={fieldSize}
             hasHelpButton={hasHelpButton}
         >
@@ -63,6 +65,7 @@ DaSelect.propTypes = {
     isRounded: PropTypes.bool,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
+    hasStaticWidth: PropTypes.bool,
     hasHelpButton: PropTypes.bool,
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
@@ -76,6 +79,7 @@ DaSelect.defaultProps = {
     isRounded: false,
     fieldSize: buttonSizeDefault,
     blockWidth: inputWidthDefault,
+    hasStaticWidth: false,
     hasHelpButton: false,
 };
 

--- a/src/lib/DaSelect/DaSelect.stories.js
+++ b/src/lib/DaSelect/DaSelect.stories.js
@@ -49,6 +49,7 @@ storiesOf(folder.form + 'DaSelect', module)
                 inputWidthOptions,
                 inputWidthDefault,
             )}
+            hasStaticWidth={boolean('Has static width', false)}
             hasHelpButton={boolean('Help button', false)}
         />
     ));

--- a/src/lib/DaSelect/__snapshots__/DaSelect.test.js.snap
+++ b/src/lib/DaSelect/__snapshots__/DaSelect.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaSelectBase-yl4pzp-0 itxPgY"
+  className="style__DaSelectBase-yl4pzp-0 ingGkz"
 >
   <select
     disabled={false}

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -5,13 +5,14 @@ import {
     enabled,
     disabled,
     helpButtonStyle,
+    widthStyle,
 } from '../../DaInput/style/base';
 
 const DaSelectBase = styled.div`
     position: relative;
-    max-width: ${props => props.theme.form.inputWidth[props.blockWidth]};
     display: flex;
     align-items: center;
+    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
 
     select {
         ${field};

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -12,7 +12,6 @@ const DaSelectBase = styled.div`
     position: relative;
     display: flex;
     align-items: center;
-    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
 
     select {
         ${field};
@@ -34,6 +33,7 @@ const DaSelectBase = styled.div`
     }
 
     ${props => (props.hasHelpButton ? helpButtonStyle : null)};
+    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
 
     &::after {
         content: '';

--- a/src/lib/DaTextarea/DaTextarea.js
+++ b/src/lib/DaTextarea/DaTextarea.js
@@ -27,6 +27,7 @@ const DaTextarea = props => {
         isRounded,
         fieldSize,
         blockWidth,
+        hasStaticWidth,
         inputRef,
         ...rest
     } = props;
@@ -62,6 +63,7 @@ const DaTextarea = props => {
             fieldSize={fieldSize}
             isRounded={isRounded}
             blockWidth={blockWidth}
+            hasStaticWidth={hasStaticWidth}
             hasCounter={hasCounter}
             autoHeight={textAreaAutoHeight}
         >
@@ -91,6 +93,7 @@ DaTextarea.propTypes = {
     counterText: PropTypes.string,
     isRounded: PropTypes.bool,
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
+    hasStaticWidth: PropTypes.bool,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
@@ -108,6 +111,7 @@ DaTextarea.defaultProps = {
     counterText: 'characters',
     isRounded: false,
     blockWidth: inputWidthDefault,
+    hasStaticWidth: false,
     fieldSize: buttonSizeDefault,
 };
 

--- a/src/lib/DaTextarea/DaTextarea.stories.js
+++ b/src/lib/DaTextarea/DaTextarea.stories.js
@@ -30,5 +30,6 @@ storiesOf(folder.form + 'DaTextarea', module)
                 inputWidthOptions,
                 inputWidthDefault,
             )}
+            hasStaticWidth={boolean('Has static width', false)}
         />
     ));

--- a/src/lib/DaTextarea/__snapshots__/DaTextarea.test.js.snap
+++ b/src/lib/DaTextarea/__snapshots__/DaTextarea.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaTextareaBase-cqgkmw-0 eFHlRi"
+  className="style__DaTextareaBase-cqgkmw-0 kJDcNd"
 >
   <textarea
     disabled={false}

--- a/src/lib/DaTextarea/style/base.js
+++ b/src/lib/DaTextarea/style/base.js
@@ -39,4 +39,13 @@ const borderRadius = {
     `,
 };
 
-export { enabled, disabled, borderRadius };
+const widthStyle = {
+    fit: css`
+        max-width: ${props => props.theme.form.inputWidth[props.blockWidth]};
+    `,
+    static: css`
+        width: 100%;
+    `,
+};
+
+export { enabled, disabled, borderRadius, widthStyle };

--- a/src/lib/DaTextarea/style/index.js
+++ b/src/lib/DaTextarea/style/index.js
@@ -1,11 +1,10 @@
 import styled from 'styled-components';
 import { math } from 'polished';
-import { enabled, disabled, borderRadius } from './base';
+import { enabled, disabled, borderRadius, widthStyle } from './base';
 
 const DaTextareaBase = styled.div`
     position: relative;
-    max-width: ${props => props.theme.form.inputWidth[props.blockWidth]};
-
+    ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
     ${props => (props.inputDisabled ? disabled : enabled)};
 
     textarea {

--- a/src/lib/FormControl/FormControl.js
+++ b/src/lib/FormControl/FormControl.js
@@ -13,7 +13,13 @@ import DatePicker from '../DatePicker/DatePicker';
 import Message from '../Message/Message';
 import { FormControlBase } from './style';
 
-const FormControl = ({ children, required, colorStatus, ...rest }) => {
+const FormControl = ({
+    children,
+    required,
+    colorStatus,
+    hasStaticWidth,
+    ...rest
+}) => {
     let hasHelpButton = false;
 
     React.Children.map(children, child => {
@@ -27,6 +33,7 @@ const FormControl = ({ children, required, colorStatus, ...rest }) => {
             {...rest}
             colorStatus={colorStatus}
             hasHelpButton={hasHelpButton}
+            hasStaticWidth={hasStaticWidth}
         >
             {React.Children.map(children, child => {
                 switch (child && child.type) {
@@ -37,12 +44,14 @@ const FormControl = ({ children, required, colorStatus, ...rest }) => {
                     case Message:
                         return React.cloneElement(child, {
                             colorStatus: colorStatus,
+                            hasStaticWidth: hasStaticWidth,
                         });
                     case DaInput:
                     case DaSelect:
                     case DatePicker:
                         return React.cloneElement(child, {
                             hasHelpButton: hasHelpButton,
+                            hasStaticWidth: hasStaticWidth,
                             required: required,
                         });
                     default:

--- a/src/lib/FormControl/FormControl.js
+++ b/src/lib/FormControl/FormControl.js
@@ -9,6 +9,7 @@ import {
 import DaHelp from '../DaHelp/DaHelp';
 import DaInput from '../DaInput/DaInput';
 import DaSelect from '../DaSelect/DaSelect';
+import DaTextarea from '../DaTextarea/DaTextarea';
 import DatePicker from '../DatePicker/DatePicker';
 import Message from '../Message/Message';
 import { FormControlBase } from './style';
@@ -54,6 +55,11 @@ const FormControl = ({
                             hasStaticWidth: hasStaticWidth,
                             required: required,
                         });
+                    case DaTextarea:
+                        return React.cloneElement(child, {
+                            hasStaticWidth: hasStaticWidth,
+                            required: required,
+                        });
                     default:
                         return React.cloneElement(child, {
                             required: required,
@@ -69,6 +75,7 @@ FormControl.propTypes = {
     required: PropTypes.bool,
     marginTop: PropTypes.oneOf(Object.values(spaceOptions)),
     marginBottom: PropTypes.oneOf(Object.values(spaceOptions)),
+    hasStaticWidth: PropTypes.bool,
 };
 
 FormControl.defaultProps = {
@@ -76,6 +83,7 @@ FormControl.defaultProps = {
     required: false,
     marginTop: spaceDefault,
     marginBottom: spaceDefault,
+    hasStaticWidth: false,
 };
 
 export default FormControl;

--- a/src/lib/FormControl/FormControl.stories.js
+++ b/src/lib/FormControl/FormControl.stories.js
@@ -156,6 +156,7 @@ storiesOf(folder.form + 'FormControl', module)
                 formStatusDefault,
             )}
             required={boolean(requiredLabel, false)}
+            hasStaticWidth={boolean('Has static width', false)}
         >
             <DaLabel>Textarea description</DaLabel>
 

--- a/src/lib/FormControl/FormControl.stories.js
+++ b/src/lib/FormControl/FormControl.stories.js
@@ -78,16 +78,8 @@ storiesOf(folder.form + 'FormControl', module)
                 formStatusDefault,
             )}
             required={boolean(requiredLabel, false)}
-            marginTop={select(
-                'Margin top',
-                spaceOptions,
-                spaceDefault,
-            )}
-            marginBottom={select(
-                'Margin bottom',
-                spaceOptions,
-                spaceDefault,
-            )}
+            marginTop={select('Margin top', spaceOptions, spaceDefault)}
+            marginBottom={select('Margin bottom', spaceOptions, spaceDefault)}
         >
             <DaLabel>Select label</DaLabel>
 
@@ -106,6 +98,7 @@ storiesOf(folder.form + 'FormControl', module)
                 formStatusDefault,
             )}
             required={boolean(requiredLabel, false)}
+            hasStaticWidth={boolean('Has static width', false)}
         >
             <DaLabel>Input label</DaLabel>
 

--- a/src/lib/FormControl/style/base.js
+++ b/src/lib/FormControl/style/base.js
@@ -14,8 +14,7 @@ const statusStyle = css`
     ${DaSelectBase} select,
     ${DaInputBase} input,
     ${DaTextareaBase} textarea {
-        border-color: ${props =>
-            props.theme.status[props.colorStatus].main};
+        border-color: ${props => props.theme.status[props.colorStatus].main};
 
         &:hover,
         &:active,
@@ -27,7 +26,7 @@ const statusStyle = css`
 
     ${DaLabelBase} {
         color: ${props => props.theme.status[props.colorStatus].main};
-       
+
         .required {
             color: ${props => props.theme.status[props.colorStatus].main};
         }
@@ -47,8 +46,7 @@ const statusStyle = css`
 
         & > .icon {
             svg {
-                fill: ${props =>
-                    props.theme.status[props.colorStatus].main};
+                fill: ${props => props.theme.status[props.colorStatus].main};
             }
         }
     }
@@ -65,7 +63,7 @@ const statusStyle = css`
             }
         }
     }
-    
+
     ${CheckboxBase} {
         input {
             &:checked {
@@ -85,7 +83,8 @@ const statusStyle = css`
 const gridStyle = css`
     display: grid;
     grid-template-areas: 'label label' 'field help' 'message message';
-    grid-template-columns: auto 1fr;
+    grid-template-columns: ${props =>
+        props.hasStaticWidth ? '1fr auto' : 'auto 1fr'};
 
     ${DaLabelBase} {
         grid-area: label;


### PR DESCRIPTION
## Ce qui a été fait :  
- ajout d'un booléen `hasStaticWidth` au DaSelect, DaInput, DaTextarea pour avoir une width à 100% quand nécessaire
- update du `FormControl` pour passer la props à tous les enfants qui en ont besoin

## Comment tester : 
-  `yarn start` 
- les stories du `FormControl`, `DaInput, `DaSelect`, `DaTextarea`