### PR TITLE
PGF-246 : ajout de la possibilité de mettre un icon à l'intérieur des DaInput, DaSelect et DatePicker

### DIFF
--- a/src/lib/DaHelp/DaHelp.js
+++ b/src/lib/DaHelp/DaHelp.js
@@ -13,14 +13,12 @@ const DaHelp = props => {
 
 DaHelp.propTypes = {
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
-    disabled: PropTypes.bool,
     isActive: PropTypes.bool,
     isRounded: PropTypes.bool,
 };
 
 DaHelp.defaultProps = {
     fieldSize: buttonSizeDefault,
-    disabled: false,
     isActive: false,
     isRounded: false,
 };

--- a/src/lib/DaHelp/DaHelp.stories.js
+++ b/src/lib/DaHelp/DaHelp.stories.js
@@ -18,7 +18,6 @@ storiesOf(folder.form + folder.sub.button + 'DaHelp', module)
                 buttonSizeOptions,
                 buttonSizeDefault,
             )}
-            disabled={boolean('Disabled', false)}
             isActive={boolean('Is active', false)}
             isRounded={boolean('Is rounded', false)}
         >

--- a/src/lib/DaHelp/__snapshots__/DaHelp.test.js.snap
+++ b/src/lib/DaHelp/__snapshots__/DaHelp.test.js.snap
@@ -2,8 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <button
-  className="style__DaHelpBase-sc-448mi1-0 cXyuEf"
-  disabled={false}
+  className="style__DaHelpBase-sc-448mi1-0 jGLIKS"
   type="button"
 >
   <span

--- a/src/lib/DaHelp/style/base.js
+++ b/src/lib/DaHelp/style/base.js
@@ -15,41 +15,19 @@ const activeStyle = css`
     }
 `;
 
-const enabled = css`
-    background-color: ${props => props.theme.status.default.light};
-
-    &:hover,
-    &:active,
-    &:focus {
-        ${activeStyle};
-    }
-
-    & > .icon {
-        svg {
-            fill: ${props => props.theme.status.default.main};
-        }
-    }
-
-    ${props => (props.isActive ? activeStyle : null)};
-`;
-
-const disabled = css`
-    ${activeStyle};
-
-    cursor: not-allowed;
-    filter: grayscale(1);
-`;
-
 const borderRadius = {
     normal: css`
-        border-radius: ${props => props.theme.radius.sm};
+        border-top-right-radius: ${props => props.theme.radius.sm};
+        border-bottom-right-radius: ${props => props.theme.radius.sm};
     `,
     rounded: css`
-        border-radius: ${props =>
+        border-top-right-radius: ${props =>
+            math(props.theme.daButton.buttonHeight[props.fieldSize] + '/2')};
+        border-bottom-right-radius: ${props =>
             math(props.theme.daButton.buttonHeight[props.fieldSize] + '/2')};
         padding-right: ${props =>
             math(props.theme.daButton.buttonHeight[props.fieldSize] + '/10')};
     `,
 };
 
-export { enabled, disabled, borderRadius };
+export { activeStyle, borderRadius };

--- a/src/lib/DaHelp/style/index.js
+++ b/src/lib/DaHelp/style/index.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { enabled, disabled, borderRadius } from './base';
+import { activeStyle, borderRadius } from './base';
 
 const DaHelpBase = styled.button`
     box-sizing: border-box;
@@ -7,17 +7,26 @@ const DaHelpBase = styled.button`
     height: ${props => props.theme.daButton.buttonHeight[props.fieldSize]};
     padding: 0;
     border: none;
-    ${props => props.isRounded ? borderRadius.rounded : borderRadius.normal};
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    background-color: ${props => props.theme.status.default.light};
     transition: all ${props => props.theme.transition.xs};
+
+    &:hover,
+    &:active,
+    &:focus {
+        ${activeStyle};
+    }
 
     & > .icon {
         width: ${props => props.theme.icon.size[props.fieldSize]};
         height: auto;
+
+        svg {
+            fill: ${props => props.theme.status.default.main};
+        }
     }
 
-    ${props => (props.disabled ? disabled : enabled)};
+    ${props => (props.isRounded ? borderRadius.rounded : borderRadius.normal)};
+    ${props => (props.isActive ? activeStyle : null)};
 `;
 
 export { DaHelpBase };

--- a/src/lib/DaInput/DaInput.js
+++ b/src/lib/DaInput/DaInput.js
@@ -17,6 +17,7 @@ const DaInput = props => {
         blockWidth,
         hasHelpButton,
         hasStaticWidth,
+        icon,
         // remove mask from rest
         mask,
         ...rest
@@ -41,7 +42,14 @@ const DaInput = props => {
             blockWidth={blockWidth}
             hasHelpButton={hasHelpButton}
             hasStaticWidth={hasStaticWidth}
+            hasIcon={!!icon}
         >
+            {icon
+                ? React.cloneElement(icon, {
+                      iconSize: fieldSize,
+                  })
+                : null}
+
             <InputMask {...rest} mask={stateMask} />
         </DaInputBase>
     );
@@ -57,6 +65,7 @@ DaInput.propTypes = {
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
     hasStaticWidth: PropTypes.bool,
     hasHelpButton: PropTypes.bool,
+    icon: PropTypes.element,
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.shape({ current: PropTypes.any }),
@@ -72,6 +81,7 @@ DaInput.defaultProps = {
     blockWidth: inputWidthDefault,
     hasStaticWidth: false,
     hasHelpButton: false,
+    icon: null,
 };
 
 export default DaInput;

--- a/src/lib/DaInput/DaInput.stories.js
+++ b/src/lib/DaInput/DaInput.stories.js
@@ -8,6 +8,7 @@ import {
     buttonSizeOptions,
     buttonSizeDefault,
 } from '../../shared/constants';
+import { PhoneIcon, SearchIcon } from '../Icon/Icon';
 import DaInput from './DaInput';
 
 storiesOf(folder.form + 'DaInput', module)
@@ -30,6 +31,7 @@ storiesOf(folder.form + 'DaInput', module)
             )}
             hasStaticWidth={boolean('Has static width', false)}
             hasHelpButton={boolean('Help button', false)}
+            icon={boolean('Has icon', true) ? <SearchIcon /> : null}
         />
     ))
     .add('Tel', () => (
@@ -45,5 +47,6 @@ storiesOf(folder.form + 'DaInput', module)
                 buttonSizeDefault,
             )}
             hasHelpButton={boolean('Help button', false)}
+            icon={boolean('Has icon', true) ? <PhoneIcon /> : null}
         />
     ));

--- a/src/lib/DaInput/__snapshots__/DaInput.test.js.snap
+++ b/src/lib/DaInput/__snapshots__/DaInput.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaInputBase-sc-13xli4f-0 fIVBa-D"
+  className="style__DaInputBase-sc-13xli4f-0 flOZAF"
 >
   <input
     disabled={false}

--- a/src/lib/DaInput/style/base.js
+++ b/src/lib/DaInput/style/base.js
@@ -1,5 +1,6 @@
 import { css } from 'styled-components';
 import { math } from 'polished';
+import { iconShift } from './constants';
 
 const borderRadius = {
     normal: css`
@@ -77,15 +78,6 @@ const widthStyle = {
         width: 100%;
     `,
 };
-
-const iconShift = props =>
-    math(
-        '(' +
-            props.theme.daButton.buttonHeight[props.fieldSize] +
-            ' - ' +
-            props.theme.icon.size[props.fieldSize] +
-            ')/2',
-    );
 
 const iconStyle = css`
     position: relative;

--- a/src/lib/DaInput/style/base.js
+++ b/src/lib/DaInput/style/base.js
@@ -78,4 +78,34 @@ const widthStyle = {
     `,
 };
 
-export { field, disabled, enabled, helpButtonStyle, widthStyle };
+const iconShift = props =>
+    math(
+        '(' +
+            props.theme.daButton.buttonHeight[props.fieldSize] +
+            ' - ' +
+            props.theme.icon.size[props.fieldSize] +
+            ')/2',
+    );
+
+const iconStyle = css`
+    position: relative;
+
+    .icon {
+        position: absolute;
+        pointer-events: none;
+        top: ${iconShift};
+        left: ${iconShift};
+
+        svg {
+            fill: ${props => props.theme.wab.grey30};
+        }
+    }
+
+    input,
+    select {
+        padding-left: ${props =>
+            props.theme.daButton.buttonHeight[props.fieldSize]};
+    }
+`;
+
+export { field, disabled, enabled, helpButtonStyle, widthStyle, iconStyle };

--- a/src/lib/DaInput/style/base.js
+++ b/src/lib/DaInput/style/base.js
@@ -89,7 +89,7 @@ const iconStyle = css`
         left: ${iconShift};
 
         svg {
-            fill: ${props => props.theme.wab.grey30};
+            fill: ${props => props.theme.wab.grey40};
         }
     }
 

--- a/src/lib/DaInput/style/constants.js
+++ b/src/lib/DaInput/style/constants.js
@@ -1,0 +1,12 @@
+import { math } from 'polished';
+
+const iconShift = props =>
+    math(
+        '(' +
+            props.theme.daButton.buttonHeight[props.fieldSize] +
+            ' - ' +
+            props.theme.icon.size[props.fieldSize] +
+            ')/2',
+    );
+
+export { iconShift };

--- a/src/lib/DaInput/style/index.js
+++ b/src/lib/DaInput/style/index.js
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
-import { field, enabled, disabled, helpButtonStyle, widthStyle } from './base';
+import {
+    field,
+    enabled,
+    disabled,
+    helpButtonStyle,
+    widthStyle,
+    iconStyle,
+} from './base';
 
 const DaInputBase = styled.div`
     input {
@@ -16,6 +23,7 @@ const DaInputBase = styled.div`
 
     ${props => (props.hasHelpButton ? helpButtonStyle : null)};
     ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
+    ${props => (props.hasIcon ? iconStyle : null)};
 `;
 
 export { DaInputBase };

--- a/src/lib/DaSelect/DaSelect.js
+++ b/src/lib/DaSelect/DaSelect.js
@@ -17,6 +17,7 @@ const DaSelect = props => {
         blockWidth,
         hasStaticWidth,
         hasHelpButton,
+        icon,
         // must not be passed with rest because there is no readOnly html attribute for select
         readOnly,
         inputRef,
@@ -33,7 +34,14 @@ const DaSelect = props => {
             hasStaticWidth={hasStaticWidth}
             fieldSize={fieldSize}
             hasHelpButton={hasHelpButton}
+            hasIcon={!!icon}
         >
+            {icon
+                ? React.cloneElement(icon, {
+                      iconSize: fieldSize,
+                  })
+                : null}
+
             <select {...rest} ref={inputRef}>
                 <Options
                     options={options}
@@ -74,6 +82,7 @@ DaSelect.propTypes = {
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
     hasStaticWidth: PropTypes.bool,
     hasHelpButton: PropTypes.bool,
+    icon: PropTypes.element,
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.shape({ current: PropTypes.any }),
@@ -88,6 +97,7 @@ DaSelect.defaultProps = {
     blockWidth: inputWidthDefault,
     hasStaticWidth: false,
     hasHelpButton: false,
+    icon: null,
 };
 
 export default DaSelect;

--- a/src/lib/DaSelect/DaSelect.stories.js
+++ b/src/lib/DaSelect/DaSelect.stories.js
@@ -8,6 +8,7 @@ import {
     buttonSizeOptions,
     buttonSizeDefault,
 } from '../../shared/constants';
+import { ListIcon } from '../Icon/Icon';
 import DaSelect from './DaSelect';
 
 const options = [
@@ -96,5 +97,6 @@ storiesOf(folder.form + 'DaSelect', module)
             )}
             hasStaticWidth={boolean('Has static width', false)}
             hasHelpButton={boolean('Help button', false)}
+            icon={boolean('Has icon', true) ? <ListIcon /> : null}
         />
     ));

--- a/src/lib/DaSelect/__snapshots__/DaSelect.test.js.snap
+++ b/src/lib/DaSelect/__snapshots__/DaSelect.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaSelectBase-yl4pzp-0 ingGkz"
+  className="style__DaSelectBase-yl4pzp-0 iqigut"
 >
   <select
     disabled={false}

--- a/src/lib/DaSelect/style/constants.js
+++ b/src/lib/DaSelect/style/constants.js
@@ -1,0 +1,21 @@
+import { math } from 'polished';
+
+const arrow = {
+    width: props =>
+        math(props.theme.daButton.buttonHeight[props.fieldSize] + '/7'),
+    height: props =>
+        math(props.theme.daButton.buttonHeight[props.fieldSize] + '/6'),
+    space: {
+        basic: props =>
+            math(
+                props.theme.space.sm +
+                    '+' +
+                    props.theme.daButton.buttonHeight[props.fieldSize] +
+                    '/3.5',
+            ),
+        rounded: props =>
+            math(props.theme.daButton.buttonHeight[props.fieldSize]),
+    },
+};
+
+export { arrow };

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -6,6 +6,7 @@ import {
     disabled,
     helpButtonStyle,
     widthStyle,
+    iconStyle,
 } from '../../DaInput/style/base';
 
 const DaSelectBase = styled.div`
@@ -34,6 +35,7 @@ const DaSelectBase = styled.div`
 
     ${props => (props.hasHelpButton ? helpButtonStyle : null)};
     ${props => (props.hasStaticWidth ? widthStyle.static : widthStyle.fit)};
+    ${props => (props.hasIcon ? iconStyle : null)};
 
     &::after {
         content: '';

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -59,7 +59,7 @@ const DaSelectBase = styled.div`
         border-color: transparent;
         border-top-color: ${props =>
             props.inputDisabled
-                ? props.theme.wab.grey30
+                ? props.theme.wab.grey20
                 : props.theme.wab.grey60};
     }
 `;

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -8,6 +8,7 @@ import {
     widthStyle,
     iconStyle,
 } from '../../DaInput/style/base';
+import { arrow } from './constants';
 
 const DaSelectBase = styled.div`
     position: relative;
@@ -18,11 +19,7 @@ const DaSelectBase = styled.div`
         ${field};
         appearance: none;
         padding-right: ${props =>
-            props.isRounded
-                ? math(
-                      props.theme.daButton.buttonHeight[props.fieldSize] + '/2',
-                  )
-                : props.theme.space.md};
+            props.isRounded ? arrow.space.rounded : arrow.space.basic};
 
         option {
             &:disabled {
@@ -46,16 +43,10 @@ const DaSelectBase = styled.div`
                 ? math(
                       props.theme.daButton.buttonHeight[props.fieldSize] + '/2',
                   )
-                : props.theme.space.md};
-        transform: translateX(50%);
+                : props.theme.space.sm};
         border-style: solid;
-        border-width: 0
-            ${props =>
-                math(
-                    props.theme.daButton.buttonHeight[props.fieldSize] + '/7',
-                )};
-        border-top-width: ${props =>
-            math(props.theme.daButton.buttonHeight[props.fieldSize] + '/6')};
+        border-width: 0 ${arrow.width};
+        border-top-width: ${arrow.height};
         border-color: transparent;
         border-top-color: ${props =>
             props.inputDisabled

--- a/src/lib/DaSelect/style/index.js
+++ b/src/lib/DaSelect/style/index.js
@@ -50,7 +50,7 @@ const DaSelectBase = styled.div`
         border-color: transparent;
         border-top-color: ${props =>
             props.inputDisabled
-                ? props.theme.wab.grey20
+                ? props.theme.wab.grey30
                 : props.theme.wab.grey60};
     }
 `;

--- a/src/lib/DatePicker/Calendar/Calendar.test.js
+++ b/src/lib/DatePicker/Calendar/Calendar.test.js
@@ -15,7 +15,7 @@ const Calendar_withContext = () => {
     return (
         <DropdownContext.Provider value={[setOpen, isOpen]}>
             <DateContextProvider value={[selectedDate, setSelectedDate]}>
-                <Calendar theme={ThemeDefault} />
+                <Calendar theme={ThemeDefault} currentMonth={selectedDate.month()} />
             </DateContextProvider>
         </DropdownContext.Provider>
     );

--- a/src/lib/DatePicker/CalendarNavbar/CalendarNavbar.test.js
+++ b/src/lib/DatePicker/CalendarNavbar/CalendarNavbar.test.js
@@ -6,7 +6,10 @@ import { MonthContextProvider } from '../context/MonthContext';
 import CalendarNavbar from './CalendarNavbar';
 
 const CalendarNavbar_withContext = () => {
-    const [month, setMonth] = useState(moment().month());
+    const [month, setMonth] = useState(
+        moment('2021-04-23T15:00:00.000').month(),
+    );
+
     return (
         <MonthContextProvider value={[month, setMonth]}>
             <CalendarNavbar theme={ThemeDefault} />

--- a/src/lib/DatePicker/DatePicker.js
+++ b/src/lib/DatePicker/DatePicker.js
@@ -200,6 +200,7 @@ DatePicker.propTypes = {
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     blockWidth: PropTypes.oneOf(Object.values(inputWidthOptions)),
     hasHelpButton: PropTypes.bool,
+    icon: PropTypes.element,
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.shape({ current: PropTypes.any }),

--- a/src/lib/DatePicker/DatePicker.stories.js
+++ b/src/lib/DatePicker/DatePicker.stories.js
@@ -17,6 +17,7 @@ import {
     localeDefault,
     localeOptions,
 } from '../../shared/constants';
+import { ScheduleIcon } from '../Icon/Icon';
 import DatePicker from './DatePicker';
 
 // This wrapper helps to deal with react hooks without having to use React.createElement() inside stories that would make the story rerender with each prop's change
@@ -56,5 +57,6 @@ storiesOf(folder.form + 'DatePicker', module)
                 moment().add(1, 'M').format('DD/MM/YYYY'),
             )}
             resetDate={text('Reset date', moment().format('DD/MM/YYYY'))}
+            icon={boolean('Has icon', true) ? <ScheduleIcon /> : null}
         />
     ));

--- a/src/lib/DatePicker/DatePicker.test.js
+++ b/src/lib/DatePicker/DatePicker.test.js
@@ -1,11 +1,16 @@
 import React from 'react';
+import moment from 'moment';
 import TestRenderer from 'react-test-renderer';
 import { ThemeDefault } from '../../theme';
 import DatePicker from './DatePicker';
 
 it('renders without crashing', () => {
     const datePicker = TestRenderer.create(
-        <DatePicker theme={ThemeDefault} onChange={() => {}} />,
+        <DatePicker
+            theme={ThemeDefault}
+            value={moment('2021-04-23T15:00:00.000')}
+            onChange={() => {}}
+        />,
     );
     expect(datePicker.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/src/lib/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders without crashing 1`] = `
       className="style__DropdownBase-ht2epv-0 dYNCxh"
     >
       <div
-        className="style__DaInputBase-sc-13xli4f-0 iDYsmg"
+        className="style__DaInputBase-sc-13xli4f-0 flOZAF"
       >
         <input
           disabled={false}
@@ -468,7 +468,7 @@ exports[`renders without crashing 1`] = `
             }
           }
           type="text"
-          value=""
+          value={"2021-04-23T13:00:00.000Z"}
         />
       </div>
       <div
@@ -688,7 +688,7 @@ exports[`renders without crashing 1`] = `
             22
           </button>
           <button
-            className="style__CalendarCellBase-sc-17uxo6m-0 cEItIt"
+            className="style__CalendarCellBase-sc-17uxo6m-0 kqyGos"
             onClick={[Function]}
             type="button"
           >

--- a/src/lib/FormControl/FormControl.stories.js
+++ b/src/lib/FormControl/FormControl.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 import {
@@ -91,40 +91,45 @@ storiesOf(folder.form + 'FormControl', module)
             />
         </FormControl>
     ))
-    .add('FormControl with DaInput, DaHelp and Message', () => (
-        <FormControl
-            colorStatus={select(
-                colorStatusLabel,
-                formStatusOptions,
-                formStatusDefault,
-            )}
-            required={boolean(requiredLabel, false)}
-            hasStaticWidth={boolean('Has static width', false)}
-        >
-            <DaLabel>Input label</DaLabel>
+    .add('FormControl with DaInput, DaHelp and Message', () => {
+        const [isOpen, setOpen] = useState(false);
 
-            <DaInput
-                placeholder="Firstname Lastname"
-                blockWidth={inputWidthOptions.sm}
-                icon={boolean('Has icon', true) ? <CardsIcon /> : null}
-            />
+        return (
+            <FormControl
+                colorStatus={select(
+                    colorStatusLabel,
+                    formStatusOptions,
+                    formStatusDefault,
+                )}
+                required={boolean(requiredLabel, false)}
+                hasStaticWidth={boolean('Has static width', false)}
+            >
+                <DaLabel>Input label</DaLabel>
 
-            <DaHelp>
-                <QuestionBoldIcon />
-            </DaHelp>
-
-            {boolean('Is DaHelp clicked', true) ? (
-                <Message
-                    arrowBlock={blockPositionOptions.topRight}
+                <DaInput
+                    placeholder="Firstname Lastname"
                     blockWidth={inputWidthOptions.sm}
-                >
-                    {MessageContent}
-                </Message>
-            ) : (
-                <></> //to replace 'null' value and avoid error from storybook
-            )}
-        </FormControl>
-    ))
+                    icon={boolean('Has icon', true) ? <CardsIcon /> : null}
+                    disabled={boolean('Disabled', false)}
+                />
+
+                <DaHelp onClick={() => setOpen(!isOpen)}>
+                    <QuestionBoldIcon />
+                </DaHelp>
+
+                {isOpen ? (
+                    <Message
+                        arrowBlock={blockPositionOptions.topRight}
+                        blockWidth={inputWidthOptions.sm}
+                    >
+                        {MessageContent}
+                    </Message>
+                ) : (
+                    <></> //to replace 'null' value and avoid error from storybook
+                )}
+            </FormControl>
+        );
+    })
     .add('Form Control with CheckboxGroup and Message', () => (
         <FormControl
             colorStatus={select(

--- a/src/lib/FormControl/FormControl.stories.js
+++ b/src/lib/FormControl/FormControl.stories.js
@@ -20,7 +20,7 @@ import DaTextarea from '../DaTextarea/DaTextarea';
 import Message from '../Message/Message';
 import CheckboxGroup from '../CheckboxGroup/CheckboxGroup';
 import Text from '../Text/Text';
-import { QuestionBoldIcon } from '../Icon/Icon';
+import { CardsIcon, QuestionBoldIcon, UsersIcon } from '../Icon/Icon';
 import FormControl from './FormControl';
 
 const colorStatusLabel = 'Status color';
@@ -87,6 +87,7 @@ storiesOf(folder.form + 'FormControl', module)
                 defaultValue=""
                 options={selectOptions}
                 blockWidth={inputWidthOptions.sm}
+                icon={boolean('Has icon', true) ? <UsersIcon /> : null}
             />
         </FormControl>
     ))
@@ -105,6 +106,7 @@ storiesOf(folder.form + 'FormControl', module)
             <DaInput
                 placeholder="Firstname Lastname"
                 blockWidth={inputWidthOptions.sm}
+                icon={boolean('Has icon', true) ? <CardsIcon /> : null}
             />
 
             <DaHelp>

--- a/src/lib/FormControl/__snapshots__/FormControl.test.js.snap
+++ b/src/lib/FormControl/__snapshots__/FormControl.test.js.snap
@@ -10,7 +10,7 @@ exports[`renders without crashing 1`] = `
     Label Description
   </label>
   <div
-    className="style__DaTextareaBase-cqgkmw-0 eFHlRi"
+    className="style__DaTextareaBase-cqgkmw-0 kJDcNd"
   >
     <textarea
       disabled={false}

--- a/src/lib/FormControl/style/base.js
+++ b/src/lib/FormControl/style/base.js
@@ -11,6 +11,15 @@ import { RadioGroupBase } from '../../RadioGroup/style';
 import { RadioBase } from '../../Radio/style';
 
 const statusStyle = css`
+    ${DaSelectBase},
+    ${DaInputBase} {
+        & > .icon {
+            svg {
+                fill: ${props => props.theme.status[props.colorStatus].main};
+            }
+        }
+    }
+
     ${DaSelectBase} select,
     ${DaInputBase} input,
     ${DaTextareaBase} textarea {

--- a/src/shared/global.js
+++ b/src/shared/global.js
@@ -60,6 +60,10 @@ export const GlobalStyle = createGlobalStyle`
         outline: none;
     }
 
+    select {
+        opacity: 1;
+    }
+
     [type="checkbox"],
     [type="radio"] {
         box-shadow: none;


### PR DESCRIPTION
- Ajout d'icons via uen props `icon` dans les DaInput, DaSelect (et DatePicker via son DaInput). Les tailles et couleurs sont gérées automatiquement par les composants parents, y'a juste à glisser l'icon de son choix et pof ça marche 🎉 
- Fix du padding-right des DaSelect
- Fix de l'opacité des select disabled (merci Chrome t'es le meilleur change rien 🖕 )
- Retrait de l'option "disabled" dans les DaHelp (c'est inutile, si on veut pas aider l'utilisateur on n'affiche pas le bouton, pas la peine de lui flanquer le seum)
- Fix dans les tests de certains composants du DatePicker pour éviter que les snapshots changent à chaque mois (maintenant c'est bon, avant j'avais juste fixé les changements de jour, mais là normalement même les changements d'années devraient plus MAJ les snapshots, c'est pas la teuf ici)
- Amélioration de la story du FormControl avec le DaHelp et Message (désormais, suffit de cliquer pour ouvrir/fermer le message, plus besoin de jouer avec la checkbox, on n'est pas des rigolos à la fin)

Ce qu'il faut tester : 
- DaInput
- DaSelect
- DatePicker
- DaHelp
- FormControl
