### PR TITLE
PGF-916: fix CSS for text inside Toggle

### DIFF
--- a/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
+++ b/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__ToggleBase-gnd37d-0 gFicoD"
+  className="style__ToggleBase-gnd37d-0 kkAFNu"
 >
   <label
     htmlFor="toggle-test"

--- a/src/lib/Toggle/style/index.js
+++ b/src/lib/Toggle/style/index.js
@@ -48,11 +48,11 @@ const ToggleBase = styled.div`
                     }
 
                     .checked-label {
-                        transform: scale(1);
+                        font-size: ${props => props.theme.font.size.sm};
                     }
-
+                    
                     .not-checked-label {
-                        transform: scale(0);
+                        font-size: 0;
                     }
                 }
             }
@@ -93,15 +93,17 @@ const ToggleBase = styled.div`
             .checked-label,
             .not-checked-label {
                 box-sizing: border-box;
+                display: flex;
                 min-width: ${props => props.theme.form.toggle};
             }
-
+            
             .checked-label {
-                transform: scale(0);
+                font-size: 0;
                 padding-left: ${props => props.theme.space.sm};
             }
-
+            
             .not-checked-label {
+                font-size: ${props => props.theme.font.size.sm};
                 padding-right: ${props => props.theme.space.sm};
                 text-align: right;
             }


### PR DESCRIPTION
Le Toggle fonctionne bien avec de petits textes, mais dès que ce sont des mots trop longs ou inégaux, ça se passe moyen.

- Diminution de la taille du texte
- Display flex pour avoir un rendu bien centré
- Utilisation de la font comme élément d'apparition/disparition plutôt qu'un transform, qui reste "visible" dans le container (ce qui donne des Toggle super larges)