### PR TITLE
PGF-944: isResponsive prop on Text and Title

### DIFF
--- a/src/lib/Card/__snapshots__/Card.test.js.snap
+++ b/src/lib/Card/__snapshots__/Card.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders without crashing 1`] = `
   type={null}
 >
   <span
-    className="style__TitleBase-td7fx4-0 gdGTKk"
+    className="style__TitleBase-td7fx4-0 WZgoj"
   >
     Content 
     <strong>
@@ -14,7 +14,7 @@ exports[`renders without crashing 1`] = `
     </strong>
   </span>
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
     <strong>

--- a/src/lib/DaTableHead/__snapshots__/DaTableHead.test.js.snap
+++ b/src/lib/DaTableHead/__snapshots__/DaTableHead.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders without crashing 1`] = `
     onClick={[Function]}
   >
     <span
-      className="style__TitleBase-td7fx4-0 icBJaJ"
+      className="style__TitleBase-td7fx4-0 knreaw"
     >
       Search and filters
     </span>

--- a/src/lib/DataLegend/__snapshots__/DataLegend.test.js.snap
+++ b/src/lib/DataLegend/__snapshots__/DataLegend.test.js.snap
@@ -15,7 +15,7 @@ exports[`renders without crashing 1`] = `
     %
   </span>
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     dolor sit amet, consectetur
   </p>

--- a/src/lib/FormControl/__snapshots__/FormControl.test.js.snap
+++ b/src/lib/FormControl/__snapshots__/FormControl.test.js.snap
@@ -41,7 +41,7 @@ exports[`renders without crashing 1`] = `
     className="style__MessageBase-ts6lfl-0 dflKhm"
   >
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Lorem ipsum dolor sit amet, consectetur non sodales.
     </p>

--- a/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
+++ b/src/lib/Histogram/YAxis/__snapshots__/YAxis.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders without crashing 1`] = `
     className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
   >
     <span
-      className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+      className="style__TextBase-sc-11ixwvd-0 bhESGB"
     >
       123
        
@@ -19,7 +19,7 @@ exports[`renders without crashing 1`] = `
     className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
   >
     <span
-      className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+      className="style__TextBase-sc-11ixwvd-0 bhESGB"
     >
       107
        
@@ -30,7 +30,7 @@ exports[`renders without crashing 1`] = `
     className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
   >
     <span
-      className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+      className="style__TextBase-sc-11ixwvd-0 bhESGB"
     >
       64
        
@@ -41,7 +41,7 @@ exports[`renders without crashing 1`] = `
     className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
   >
     <span
-      className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+      className="style__TextBase-sc-11ixwvd-0 bhESGB"
     >
       34.5
        
@@ -52,7 +52,7 @@ exports[`renders without crashing 1`] = `
     className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
   >
     <span
-      className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+      className="style__TextBase-sc-11ixwvd-0 bhESGB"
     >
       0
        

--- a/src/lib/Histogram/__snapshots__/Histogram.test.js.snap
+++ b/src/lib/Histogram/__snapshots__/Histogram.test.js.snap
@@ -11,7 +11,7 @@ exports[`renders without crashing 1`] = `
       className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
     >
       <span
-        className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+        className="style__TextBase-sc-11ixwvd-0 bhESGB"
       >
         110
          
@@ -21,7 +21,7 @@ exports[`renders without crashing 1`] = `
       className="style__YAxisElementBase-fqe2pn-1 bUfzZn"
     >
       <span
-        className="style__TextBase-sc-11ixwvd-0 jhNWiV"
+        className="style__TextBase-sc-11ixwvd-0 bhESGB"
       >
         0
          

--- a/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
+++ b/src/lib/HistogramBar/__snapshots__/HistogramBar.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders without crashing 1`] = `
     className="style__MessageBase-ts6lfl-0 jRGXuP"
   >
     <p
-      className="style__TextBase-sc-11ixwvd-0 ePvKFZ"
+      className="style__TextBase-sc-11ixwvd-0 PblDx"
     >
       60 in label
     </p>

--- a/src/lib/List/__snapshots__/List.test.js.snap
+++ b/src/lib/List/__snapshots__/List.test.js.snap
@@ -13,7 +13,7 @@ exports[`renders without crashing 1`] = `
         className="bullet"
       />
       <p
-        className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+        className="style__TextBase-sc-11ixwvd-0 hKuksH"
       >
         Something
       </p>
@@ -28,7 +28,7 @@ exports[`renders without crashing 1`] = `
         className="bullet"
       />
       <p
-        className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+        className="style__TextBase-sc-11ixwvd-0 hKuksH"
       >
         Something else
       </p>

--- a/src/lib/ListHorizontal/__snapshots__/ListHorizontal.test.js.snap
+++ b/src/lib/ListHorizontal/__snapshots__/ListHorizontal.test.js.snap
@@ -6,7 +6,7 @@ exports[`renders without crashing 1`] = `
 >
   <li>
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Text 1
     </p>
@@ -16,7 +16,7 @@ exports[`renders without crashing 1`] = `
       className="style__DotBase-dbqcuj-0 iNACDc"
     />
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Text 2
     </p>
@@ -26,7 +26,7 @@ exports[`renders without crashing 1`] = `
       className="style__DotBase-dbqcuj-0 iNACDc"
     />
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Text 3
     </p>

--- a/src/lib/ListItem/__snapshots__/ListItem.test.js.snap
+++ b/src/lib/ListItem/__snapshots__/ListItem.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders without crashing 1`] = `
     className="bullet"
   />
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     Something
   </p>

--- a/src/lib/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/lib/Menu/__snapshots__/Menu.test.js.snap
@@ -41,7 +41,7 @@ exports[`renders without crashing 1`] = `
             Tree
           </span>
           <p
-            className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+            className="style__TextBase-sc-11ixwvd-0 hKuksH"
           >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet accumsan dolor. Nullam fringilla quam leo.
           </p>

--- a/src/lib/MenuList/__snapshots__/MenuList.test.js.snap
+++ b/src/lib/MenuList/__snapshots__/MenuList.test.js.snap
@@ -29,7 +29,7 @@ exports[`renders without crashing 1`] = `
           Tree
         </span>
         <p
-          className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+          className="style__TextBase-sc-11ixwvd-0 hKuksH"
         >
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet accumsan dolor. Nullam fringilla quam leo.
         </p>

--- a/src/lib/MenuListItem/__snapshots__/MenuListItem.test.js.snap
+++ b/src/lib/MenuListItem/__snapshots__/MenuListItem.test.js.snap
@@ -51,7 +51,7 @@ exports[`renders without crashing 1`] = `
       Dev
     </span>
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet accumsan dolor. Nullam fringilla quam leo, id bibendum felis iaculis eu.
     </p>

--- a/src/lib/MenuPrimary/__snapshots__/MenuPrimary.test.js.snap
+++ b/src/lib/MenuPrimary/__snapshots__/MenuPrimary.test.js.snap
@@ -53,7 +53,7 @@ exports[`renders without crashing 1`] = `
               Tree
             </span>
             <p
-              className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+              className="style__TextBase-sc-11ixwvd-0 hKuksH"
             >
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet accumsan dolor. Nullam fringilla quam leo.
             </p>

--- a/src/lib/Message/__snapshots__/Message.test.js.snap
+++ b/src/lib/Message/__snapshots__/Message.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__MessageBase-ts6lfl-0 dflKhm"
 >
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     Lorem ipsum dolor sit amet, consectetur non sodales.
   </p>

--- a/src/lib/Modal/__snapshots__/Modal.test.js.snap
+++ b/src/lib/Modal/__snapshots__/Modal.test.js.snap
@@ -14,7 +14,7 @@ exports[`renders without crashing 1`] = `
       className="style__ModalBodyBase-md16g0-0 lhDNNM"
     >
       <p
-        className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+        className="style__TextBase-sc-11ixwvd-0 hKuksH"
       >
         This is the body.
       </p>

--- a/src/lib/ModalBody/__snapshots__/ModalBody.test.js.snap
+++ b/src/lib/ModalBody/__snapshots__/ModalBody.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__ModalBodyBase-md16g0-0 lhDNNM"
 >
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     This is the body.
   </p>

--- a/src/lib/ModalContent/__snapshots__/ModalContent.test.js.snap
+++ b/src/lib/ModalContent/__snapshots__/ModalContent.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders without crashing 1`] = `
     className="style__ModalHeaderBase-e1z6bj-0 hqembS"
   >
     <span
-      className="style__TitleBase-td7fx4-0 gdGTKk"
+      className="style__TitleBase-td7fx4-0 WZgoj"
     >
       This is the Title
     </span>
@@ -17,7 +17,7 @@ exports[`renders without crashing 1`] = `
     className="style__ModalBodyBase-md16g0-0 lhDNNM"
   >
     <p
-      className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+      className="style__TextBase-sc-11ixwvd-0 hKuksH"
     >
       Curabitur congue varius ex et posuere. Maecenas tincidunt diam ut nisl porttitor scelerisque.Curabitur congue varius ex et posuere. Maecenas tincidunt diam ut nisl porttitor scelerisque.Curabitur congue varius ex et posuere. Maecenas tincidunt diam ut nisl porttitor scelerisque.
     </p>

--- a/src/lib/ModalHeader/__snapshots__/ModalHeader.test.js.snap
+++ b/src/lib/ModalHeader/__snapshots__/ModalHeader.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__ModalHeaderBase-e1z6bj-0 hqembS"
 >
   <span
-    className="style__TitleBase-td7fx4-0 gdGTKk"
+    className="style__TitleBase-td7fx4-0 WZgoj"
   >
     This is the Title
   </span>

--- a/src/lib/SidebarMenuCategory/SidebarMenuCategory.js
+++ b/src/lib/SidebarMenuCategory/SidebarMenuCategory.js
@@ -8,19 +8,21 @@ import {
 import { SidebarMenuCategoryBase } from './style';
 import Title from '../Title/Title';
 
-const SidebarMenuCategory = props => {
+const SidebarMenuCategory = ({ children, categoryTitle, ...rest }) => {
     return (
-        <SidebarMenuCategoryBase {...props}>
-            {props.categoryTitle ? (
+        <SidebarMenuCategoryBase {...rest}>
+            {categoryTitle ? (
                 <Title
-                    {...props}
+                    theme={rest.theme} // not necessary, only needed for tests
                     colorWab={greyOptions.grey30}
                     textSize={fontSizeOptions.xxs}
+                    isResponsive={false}
                 >
-                    {props.categoryTitle}
+                    {categoryTitle}
                 </Title>
             ) : null}
-            {props.children}
+
+            {children}
         </SidebarMenuCategoryBase>
     );
 };

--- a/src/lib/SidebarMenuCategory/__snapshots__/SidebarMenuCategory.test.js.snap
+++ b/src/lib/SidebarMenuCategory/__snapshots__/SidebarMenuCategory.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__SidebarMenuCategoryBase-sfn1v8-0 jfhnvr"
 >
   <span
-    className="style__TitleBase-td7fx4-0 jCvNZD"
+    className="style__TitleBase-td7fx4-0 UrQxC"
   >
     Categorie de pages
   </span>

--- a/src/lib/SidebarMenuCategory/__snapshots__/SidebarMenuCategory.test.js.snap
+++ b/src/lib/SidebarMenuCategory/__snapshots__/SidebarMenuCategory.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__SidebarMenuCategoryBase-sfn1v8-0 jfhnvr"
 >
   <span
-    className="style__TitleBase-td7fx4-0 hJyaAO"
+    className="style__TitleBase-td7fx4-0 jCvNZD"
   >
     Categorie de pages
   </span>

--- a/src/lib/Text/Text.js
+++ b/src/lib/Text/Text.js
@@ -38,6 +38,7 @@ Text.propTypes = {
     colorWab: PropTypes.oneOf(Object.values(greyOptions)),
     colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)),
 
+    isResponsive: PropTypes.bool,
     hasUppercase: PropTypes.bool,
     hasBackground: PropTypes.bool,
     radiusSize: PropTypes.oneOf(Object.values(radiusOptions)),
@@ -65,6 +66,7 @@ Text.defaultProps = {
     colorWab: greyOptions.grey60,
     colorStatus: formStatusDefault,
 
+    isResponsive: true,
     hasUppercase: false,
     hasBackground: false,
     radiusSize: radiusOptions.none,

--- a/src/lib/Text/Text.stories.js
+++ b/src/lib/Text/Text.stories.js
@@ -58,6 +58,7 @@ storiesOf(folder.text + 'Text', module)
                 formStatusOptions,
                 formStatusDefault,
             )}
+            isResponsive={boolean(labels.isResponsive, true)}
             textSize={select(labels.textSize, fontSizeOptions, fontSizeDefault)}
             align={radios(labels.align, alignOptions, alignDefault)}
             hasUppercase={boolean(labels.hasUppercase, false)}
@@ -102,6 +103,7 @@ storiesOf(folder.text + 'Text', module)
                 formStatusOptions,
                 formStatusDefault,
             )}
+            isResponsive={boolean(labels.isResponsive, true)}
             textSize={select(labels.textSize, fontSizeOptions, fontSizeDefault)}
             align={radios(labels.align, alignOptions, alignDefault)}
             marginLateral={select(
@@ -267,6 +269,7 @@ storiesOf(folder.text + 'Text', module)
                     formStatusDefault,
                 )}
                 marginLateral={spaceOptions.sm}
+                isResponsive={boolean(labels.isResponsive, true)}
                 textSize={select(
                     labels.textSize,
                     fontSizeOptions,

--- a/src/lib/Text/__snapshots__/Text.test.js.snap
+++ b/src/lib/Text/__snapshots__/Text.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders without crashing 1`] = `
 Array [
   <p
-    className="style__TextBase-sc-11ixwvd-0 gQgxOT"
+    className="style__TextBase-sc-11ixwvd-0 hKuksH"
   >
     Lorem ipsum dolor sit amet, consectetur
      
@@ -18,7 +18,7 @@ Array [
      laoreet sodales.
   </p>,
   <strong
-    className="style__TextBase-sc-11ixwvd-0 eoNlpI"
+    className="style__TextBase-sc-11ixwvd-0 gCdoQI"
   >
     Lorem ipsum dolor sit amet, consectetur
   </strong>,

--- a/src/lib/Text/style/base.js
+++ b/src/lib/Text/style/base.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { transparentize, math } from 'polished';
 import { responsiveSpaces } from '../../../shared/spaces';
-import { mainColor, backgroundColor } from './constants';
+import { mainColor, backgroundColor, minimizeFont } from './constants';
 
 const htmlTagStyle = {
     p: css`
@@ -79,4 +79,11 @@ const blockBackground = {
     `,
 };
 
-export { htmlTagStyle, uppercaseStyle, color, blockBackground };
+const minimizeText = css`
+    @media ${props => props.theme.screen.max.md} {
+        font-size: ${props =>
+            props.theme.font.size[minimizeFont[props.textSize]]};
+    }
+`;
+
+export { htmlTagStyle, uppercaseStyle, color, blockBackground, minimizeText };

--- a/src/lib/Text/style/constants.js
+++ b/src/lib/Text/style/constants.js
@@ -1,6 +1,5 @@
 import { transparentize } from 'polished';
 import { fontSizeOptions } from '../../../shared/constants';
-import { minimizeFont as titleMinimizeFont } from '../../Title/style/constants';
 
 const mainColor = {
     theme: props => props.theme.color[props.colorTheme].main,
@@ -21,7 +20,9 @@ const minimizeFont = {
     xs: fontSizeOptions.xxs,
     sm: fontSizeOptions.xs,
     base: fontSizeOptions.sm,
-    ...titleMinimizeFont,
+    md: fontSizeOptions.base,
+    lg: fontSizeOptions.md,
+    xl: fontSizeOptions.lg,
 };
 
 export { mainColor, backgroundColor, minimizeFont };

--- a/src/lib/Text/style/index.js
+++ b/src/lib/Text/style/index.js
@@ -1,8 +1,13 @@
 import styled from 'styled-components';
 import { responsiveSpaces } from '../../../shared/spaces';
 import { underline } from '../../Title/style/base';
-import { minimizeFont } from './constants';
-import { htmlTagStyle, uppercaseStyle, color, blockBackground } from './base';
+import {
+    htmlTagStyle,
+    uppercaseStyle,
+    color,
+    blockBackground,
+    minimizeText,
+} from './base';
 
 const TextBase = styled.p`
     ${responsiveSpaces('margin')};
@@ -10,11 +15,7 @@ const TextBase = styled.p`
     text-align: ${props => props.align};
     font-size: ${props => props.theme.font.size[props.textSize]};
 
-    @media ${props => props.theme.screen.max.md} {
-        font-size: ${props =>
-            props.theme.font.size[minimizeFont[props.textSize]]};
-    }
-
+    ${props => (props.isResponsive ? minimizeText : null)};
     ${props => htmlTagStyle[props.htmlTag]};
     ${props => color[props.colorType]};
     ${props => (props.hasBackground ? blockBackground[props.colorType] : null)};

--- a/src/lib/Title/Title.js
+++ b/src/lib/Title/Title.js
@@ -43,6 +43,7 @@ Title.propTypes = {
     colorWab: PropTypes.oneOf(Object.values(greyOptions)),
     colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)),
 
+    isResponsive: PropTypes.bool,
     textSize: PropTypes.oneOf(Object.values(fontSizeOptions)),
     align: PropTypes.oneOf(Object.values(alignOptions)),
     marginLateral: PropTypes.oneOf(Object.values(spaceOptions)),
@@ -60,6 +61,7 @@ Title.defaultProps = {
     colorWab: greyOptions.grey60,
     colorStatus: formStatusDefault,
 
+    isResponsive: true,
     textSize: fontSizeDefault,
     align: alignDefault,
     marginLateral: spaceDefault,

--- a/src/lib/Title/Title.stories.js
+++ b/src/lib/Title/Title.stories.js
@@ -46,6 +46,7 @@ storiesOf(folder.text + 'Title', module)
                 formStatusOptions,
                 formStatusDefault,
             )}
+            isResponsive={boolean(labels.isResponsive, true)}
             textSize={select(
                 labels.textSize,
                 fontSizeOptions,

--- a/src/lib/Title/__snapshots__/Title.test.js.snap
+++ b/src/lib/Title/__snapshots__/Title.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <span
-  className="style__TitleBase-td7fx4-0 gdGTKk"
+  className="style__TitleBase-td7fx4-0 WZgoj"
 >
   Your title with 
   <strong>

--- a/src/lib/Title/style/base.js
+++ b/src/lib/Title/style/base.js
@@ -2,18 +2,11 @@ import { css } from 'styled-components';
 import { transparentize } from 'polished';
 import { colorPalletOptions } from '../../../shared/constants';
 import { mainColor } from '../../Text/style/constants';
-import { lineColor, minimizeFont } from './constants';
+import { lineColor } from './constants';
 
 const smallText = css`
     text-transform: uppercase;
     letter-spacing: ${props => props.theme.font.spacing};
-`;
-
-const bigText = css`
-    @media ${props => props.theme.screen.max.md} {
-        font-size: ${props =>
-            props.theme.font.size[minimizeFont[props.textSize]]};
-    }
 `;
 
 const underlineAlign = {
@@ -71,4 +64,4 @@ const color = {
     `,
 };
 
-export { smallText, bigText, underline, color };
+export { smallText, underline, color };

--- a/src/lib/Title/style/constants.js
+++ b/src/lib/Title/style/constants.js
@@ -1,5 +1,4 @@
 import { transparentize } from 'polished';
-import { fontSizeOptions } from '../../../shared/constants';
 
 const lineColor = {
     theme: props =>
@@ -9,10 +8,4 @@ const lineColor = {
         transparentize(0.5, props.theme.status[props.colorStatus].main),
 };
 
-const minimizeFont = {
-    md: fontSizeOptions.base,
-    lg: fontSizeOptions.md,
-    xl: fontSizeOptions.lg,
-};
-
-export { lineColor, minimizeFont };
+export { lineColor };

--- a/src/lib/Title/style/index.js
+++ b/src/lib/Title/style/index.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { responsiveSpaces } from '../../../shared/spaces';
-import { smallText, bigText, underline, color } from './base';
+import { minimizeText } from '../../Text/style/base';
+import { smallText, underline, color } from './base';
 
 const TitleBase = styled.span`
     display: block;
@@ -8,7 +9,8 @@ const TitleBase = styled.span`
     font-weight: ${props => props.theme.font.weight.bold};
     font-size: ${props => props.theme.font.size[props.textSize]};
 
-    ${props => (props.isSmallText ? smallText : bigText)};
+    ${props => (props.isResponsive ? minimizeText : null)};
+    ${props => (props.isSmallText ? smallText : null)};
     ${props => color[props.colorType]};
     ${props => (props.hasUnderline ? underline : null)};
     ${props =>

--- a/src/shared/labels.js
+++ b/src/shared/labels.js
@@ -67,6 +67,7 @@ const labels = {
     hasResponsivePadding: 'Has responsive padding',
 
     // Fonts
+    isResponsive: 'Is responsive',
     textSize: 'Text size',
     hasUnderline: 'Has underline',
     hasUppercase: 'Has uppercase',


### PR DESCRIPTION
- Création d'une props `isResponsive` sur les composants **Text** et **Title**, à `true` par défaut : il est donc désormais possible de "neutraliser" la minimisation de la taille des Text et Title sur petits écrans en la forçant à `false`.
- Petits titres désormais minimisés aussi (mais c'est le comportement par défaut, ça peut donc se neutraliser)
- Update des snapshots qui embarquaient un composant Text ou Title