### PR TITLE
PGF-949: autoriser tous les types de value dans les composants de formulaire et autoriser les objets comme legend

### DIFF
--- a/src/lib/Checkbox/Checkbox.js
+++ b/src/lib/Checkbox/Checkbox.js
@@ -28,6 +28,7 @@ const Checkbox = ({ theme, fieldSize, label, inputRef, ...rest }) => {
 Checkbox.propTypes = {
     id: PropTypes.string.isRequired,
     label: PropTypes.string,
+    value: PropTypes.any,
     disabled: PropTypes.bool,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     inputRef: PropTypes.oneOfType([

--- a/src/lib/Checkbox/Checkbox.stories.js
+++ b/src/lib/Checkbox/Checkbox.stories.js
@@ -15,7 +15,6 @@ storiesOf(folder.form + folder.sub.checkbox + 'Checkbox', module)
         <Checkbox
             id="first"
             label="First Choice"
-            value="first"
             disabled={boolean(labels.disabled, false)}
             fieldSize={radios(
                 labels.fieldSize,

--- a/src/lib/Checkbox/Checkbox.stories.js
+++ b/src/lib/Checkbox/Checkbox.stories.js
@@ -15,6 +15,7 @@ storiesOf(folder.form + folder.sub.checkbox + 'Checkbox', module)
         <Checkbox
             id="first"
             label="First Choice"
+            value="first"
             disabled={boolean(labels.disabled, false)}
             fieldSize={radios(
                 labels.fieldSize,

--- a/src/lib/Checkbox/Checkbox.test.js
+++ b/src/lib/Checkbox/Checkbox.test.js
@@ -5,11 +5,7 @@ import Checkbox from './Checkbox';
 
 it('renders without crashing', () => {
     const checkbox = TestRenderer.create(
-        <Checkbox
-            theme={ThemeDefault}
-            id="first"
-            label="First Choice"
-        />,
+        <Checkbox theme={ThemeDefault} id="first" label="First Choice" />,
     );
     expect(checkbox.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/CheckboxGroup/CheckboxGroup.js
+++ b/src/lib/CheckboxGroup/CheckboxGroup.js
@@ -45,12 +45,12 @@ CheckboxGroup.propTypes = {
     options: PropTypes.arrayOf(
         PropTypes.shape({
             label: PropTypes.string.isRequired,
-            value: PropTypes.string.isRequired,
+            value: PropTypes.any.isRequired,
         }),
     ).isRequired,
     name: PropTypes.string.isRequired,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
-    legend: PropTypes.string,
+    legend: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     disabled: PropTypes.bool,
     required: PropTypes.bool,
 };

--- a/src/lib/DaSelect/DaSelect.js
+++ b/src/lib/DaSelect/DaSelect.js
@@ -55,7 +55,7 @@ DaSelect.propTypes = {
     options: PropTypes.arrayOf(
         PropTypes.oneOfType([
             PropTypes.shape({
-                value: PropTypes.string.isRequired,
+                value: PropTypes.any.isRequired,
                 text: PropTypes.string.isRequired,
                 disabled: PropTypes.bool,
             }),
@@ -65,7 +65,7 @@ DaSelect.propTypes = {
                 }),
                 PropTypes.arrayOf(
                     PropTypes.shape({
-                        value: PropTypes.string.isRequired,
+                        value: PropTypes.any.isRequired,
                         text: PropTypes.string.isRequired,
                         disabled: PropTypes.bool,
                     }),

--- a/src/lib/DaSelect/DaSelect.stories.js
+++ b/src/lib/DaSelect/DaSelect.stories.js
@@ -23,7 +23,7 @@ const options = [
         text: 'First option',
     },
     {
-        value: 'second',
+        value: 2,
         text: 'Second option',
     },
     {
@@ -46,7 +46,7 @@ const optionsGroup = [
                 text: 'First option',
             },
             {
-                value: 'second',
+                value: 2,
                 text: 'Second option',
             },
             {

--- a/src/lib/DaTable/DaTable.test.js
+++ b/src/lib/DaTable/DaTable.test.js
@@ -1,17 +1,12 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { ThemeDefault } from '../../theme';
-import Checkbox from '../Checkbox/Checkbox';
 import DaTableCell from '../DaTableCell/DaTableCell';
 import DaTableRow from '../DaTableRow/DaTableRow';
 import DaTable from './DaTable';
 
 const row = (
     <DaTableRow theme={ThemeDefault}>
-        <DaTableCell theme={ThemeDefault}>
-            <Checkbox theme={ThemeDefault} id="select"/>
-        </DaTableCell>
-
         <DaTableCell theme={ThemeDefault} isId={true}>
             4217
         </DaTableCell>

--- a/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
+++ b/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
@@ -8,42 +8,9 @@ exports[`renders without crashing 1`] = `
     className="table"
   >
     <div
-      className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
+      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
       onMouseDown={[Function]}
     >
-      <div
-        className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"
-      >
-        <span
-          className="cell-content"
-        >
-          <div
-            className="style__CheckboxBase-sc-1wlk4ud-0 bdkKKN"
-          >
-            <input
-              disabled={false}
-              id="select"
-              type="checkbox"
-            />
-            <label
-              htmlFor="select"
-            >
-              <span
-                className="style__IconBase-ak3679-0 xhyCY icon"
-                type={null}
-              >
-                <svg
-                  viewBox="0 0 143 143"
-                >
-                  <path
-                    d="M67.1 123c-1.8 0-3.5-.7-4.8-1.9l-48.6-45c-2.8-2.6-3-7.1-.4-9.9 2.6-2.8 7.1-3 9.9-.4l42.6 39.4 52.8-78.5c2.2-3.2 6.5-4.1 9.7-1.9s4.1 6.5 1.9 9.7l-57.4 85.2c-1.1 1.7-3 2.8-5 3-.1.3-.4.3-.7.3z"
-                  />
-                </svg>
-              </span>
-            </label>
-          </div>
-        </span>
-      </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
       >
@@ -73,42 +40,9 @@ exports[`renders without crashing 1`] = `
       </div>
     </div>
     <div
-      className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
+      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
       onMouseDown={[Function]}
     >
-      <div
-        className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"
-      >
-        <span
-          className="cell-content"
-        >
-          <div
-            className="style__CheckboxBase-sc-1wlk4ud-0 bdkKKN"
-          >
-            <input
-              disabled={false}
-              id="select"
-              type="checkbox"
-            />
-            <label
-              htmlFor="select"
-            >
-              <span
-                className="style__IconBase-ak3679-0 xhyCY icon"
-                type={null}
-              >
-                <svg
-                  viewBox="0 0 143 143"
-                >
-                  <path
-                    d="M67.1 123c-1.8 0-3.5-.7-4.8-1.9l-48.6-45c-2.8-2.6-3-7.1-.4-9.9 2.6-2.8 7.1-3 9.9-.4l42.6 39.4 52.8-78.5c2.2-3.2 6.5-4.1 9.7-1.9s4.1 6.5 1.9 9.7l-57.4 85.2c-1.1 1.7-3 2.8-5 3-.1.3-.4.3-.7.3z"
-                  />
-                </svg>
-              </span>
-            </label>
-          </div>
-        </span>
-      </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
       >
@@ -138,42 +72,9 @@ exports[`renders without crashing 1`] = `
       </div>
     </div>
     <div
-      className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
+      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
       onMouseDown={[Function]}
     >
-      <div
-        className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"
-      >
-        <span
-          className="cell-content"
-        >
-          <div
-            className="style__CheckboxBase-sc-1wlk4ud-0 bdkKKN"
-          >
-            <input
-              disabled={false}
-              id="select"
-              type="checkbox"
-            />
-            <label
-              htmlFor="select"
-            >
-              <span
-                className="style__IconBase-ak3679-0 xhyCY icon"
-                type={null}
-              >
-                <svg
-                  viewBox="0 0 143 143"
-                >
-                  <path
-                    d="M67.1 123c-1.8 0-3.5-.7-4.8-1.9l-48.6-45c-2.8-2.6-3-7.1-.4-9.9 2.6-2.8 7.1-3 9.9-.4l42.6 39.4 52.8-78.5c2.2-3.2 6.5-4.1 9.7-1.9s4.1 6.5 1.9 9.7l-57.4 85.2c-1.1 1.7-3 2.8-5 3-.1.3-.4.3-.7.3z"
-                  />
-                </svg>
-              </span>
-            </label>
-          </div>
-        </span>
-      </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
       >

--- a/src/lib/DaTableBody/DaTableBody.test.js
+++ b/src/lib/DaTableBody/DaTableBody.test.js
@@ -11,7 +11,7 @@ it('renders without crashing', () => {
         <DaTableBody theme={ThemeDefault}>
             <DaTableRow theme={ThemeDefault}>
                 <DaTableCell theme={ThemeDefault}>
-                    <Checkbox theme={ThemeDefault} id="select"/>
+                    <Checkbox theme={ThemeDefault} id="select" />
                 </DaTableCell>
 
                 <DaTableCell theme={ThemeDefault} isId={true}>

--- a/src/lib/DaTableHead/DaTableHead.test.js
+++ b/src/lib/DaTableHead/DaTableHead.test.js
@@ -10,7 +10,7 @@ it('renders without crashing', () => {
     const component = TestRenderer.create(
         <DaTableHead theme={ThemeDefault}>
             <DaTableHeadCell theme={ThemeDefault}>
-                <Checkbox id="select" theme={ThemeDefault}/>
+                <Checkbox theme={ThemeDefault} id="select" />
             </DaTableHeadCell>
 
             <DaTableHeadCell

--- a/src/lib/DaTableRow/DaTableRow.test.js
+++ b/src/lib/DaTableRow/DaTableRow.test.js
@@ -9,7 +9,7 @@ it('renders without crashing', () => {
     const component = TestRenderer.create(
         <DaTableRow theme={ThemeDefault}>
             <DaTableCell theme={ThemeDefault}>
-                <Checkbox theme={ThemeDefault} id="select"/>
+                <Checkbox theme={ThemeDefault} id="select" />
             </DaTableCell>
 
             <DaTableCell theme={ThemeDefault} isId={true}>

--- a/src/lib/Radio/Radio.js
+++ b/src/lib/Radio/Radio.js
@@ -17,10 +17,11 @@ const Radio = ({ theme, fieldSize, label, inputRef, ...rest }) => {
 };
 
 Radio.propTypes = {
-    fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
-    disabled: PropTypes.bool,
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
+    value: PropTypes.any.isRequired,
+    disabled: PropTypes.bool,
+    fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     inputRef: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.shape({ current: PropTypes.any }),
@@ -28,8 +29,8 @@ Radio.propTypes = {
 };
 
 Radio.defaultProps = {
-    fieldSize: buttonSizeDefault,
     disabled: false,
+    fieldSize: buttonSizeDefault,
 };
 
 export default Radio;

--- a/src/lib/Radio/Radio.stories.js
+++ b/src/lib/Radio/Radio.stories.js
@@ -15,6 +15,7 @@ storiesOf(folder.form + folder.sub.radio + 'Radio', module)
         <Radio
             id="first"
             label="First Choice"
+            value="first"
             disabled={boolean(labels.disabled, false)}
             fieldSize={radios(
                 labels.fieldSize,

--- a/src/lib/Radio/Radio.test.js
+++ b/src/lib/Radio/Radio.test.js
@@ -5,7 +5,12 @@ import Radio from './Radio';
 
 it('renders without crashing', () => {
     const radio = TestRenderer.create(
-        <Radio theme={ThemeDefault} id="first" label="First Choice" />,
+        <Radio
+            theme={ThemeDefault}
+            id="first"
+            label="First Choice"
+            value="first"
+        />,
     );
     expect(radio.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/Radio/__snapshots__/Radio.test.js.snap
+++ b/src/lib/Radio/__snapshots__/Radio.test.js.snap
@@ -8,6 +8,7 @@ exports[`renders without crashing 1`] = `
     disabled={false}
     id="first"
     type="radio"
+    value="first"
   />
   <label
     htmlFor="first"

--- a/src/lib/RadioGroup/RadioGroup.js
+++ b/src/lib/RadioGroup/RadioGroup.js
@@ -45,12 +45,12 @@ RadioGroup.propTypes = {
     options: PropTypes.arrayOf(
         PropTypes.shape({
             label: PropTypes.string.isRequired,
-            value: PropTypes.string.isRequired,
+            value: PropTypes.any.isRequired,
         }),
     ).isRequired,
     name: PropTypes.string.isRequired,
     fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
-    legend: PropTypes.string,
+    legend: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     disabled: PropTypes.bool,
     required: PropTypes.bool,
 };

--- a/src/lib/Select/Options.js
+++ b/src/lib/Select/Options.js
@@ -41,7 +41,7 @@ Options.propTypes = {
     options: PropTypes.arrayOf(
         PropTypes.oneOfType([
             PropTypes.shape({
-                value: PropTypes.string.isRequired,
+                value: PropTypes.any.isRequired,
                 text: PropTypes.string.isRequired,
                 disabled: PropTypes.bool,
             }),
@@ -51,7 +51,7 @@ Options.propTypes = {
                 }),
                 PropTypes.arrayOf(
                     PropTypes.shape({
-                        value: PropTypes.string.isRequired,
+                        value: PropTypes.any.isRequired,
                         text: PropTypes.string.isRequired,
                         disabled: PropTypes.bool,
                     }),
@@ -60,7 +60,7 @@ Options.propTypes = {
         ]),
     ).isRequired,
     readOnly: PropTypes.bool,
-    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    defaultValue: PropTypes.any,
 };
 
 Options.defaultProps = {

--- a/src/lib/Select/Select.js
+++ b/src/lib/Select/Select.js
@@ -77,7 +77,7 @@ Select.propTypes = {
     options: PropTypes.arrayOf(
         PropTypes.oneOfType([
             PropTypes.shape({
-                value: PropTypes.string.isRequired,
+                value: PropTypes.any.isRequired,
                 text: PropTypes.string.isRequired,
                 disabled: PropTypes.bool,
             }),
@@ -87,7 +87,7 @@ Select.propTypes = {
                 }),
                 PropTypes.arrayOf(
                     PropTypes.shape({
-                        value: PropTypes.string.isRequired,
+                        value: PropTypes.any.isRequired,
                         text: PropTypes.string.isRequired,
                         disabled: PropTypes.bool,
                     }),


### PR DESCRIPTION
Ce qui a été fait
----

- Autoriser tous les types de `value` dans les composants de formulaire (**CheckboxGroup** & **Checkbox**, **RadioGroup** & **Radio**, **Select**, **DaSelect**)(et dans le **Options** contenu dans le composant **Select**).
- Rendre obligatoire le `label` et la `value` dans le composant **Radio** (autant dans la **Checkbox**, on peut avoir des cas où on n'en a pas besoin - exemple : dans un tableau, la **Checkbox** peut servir pour sélectionner des lignes, ce n'est donc pas un usage "formulaire" dans lequel la value est indispensable), autant le **Radio** n'a d'intérêt qu'avec une `value`.
- Retrait des **Checkbox** dans le fichier de test du **DaTable** (déjà testé ailleurs et ici, c'était mal fichu puisque toutes les **Checkbox** avaient le même `id`, c'était pas logique).
- Autoriser les objets dans les `legend` des **CheckboxGroup** et **RadioGroup** (pour pouvoir faire passer des liens, par exemple "CGU (_lire_)").

Comment tester
-----

- Aller dans les stories des composants **CheckboxGroup**, **Checkbox**, **RadioGroup**, **Radio**, **Select**, et **DaSelect**
- Vérifier qu'il n'y a pas d'erreur en console
