### PR TITLE
PGF-982: improve IconLabel

### DIFF
--- a/src/lib/IconLabel/IconLabel.js
+++ b/src/lib/IconLabel/IconLabel.js
@@ -1,19 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    colorPalletOptions,
+    colorPalletDefault,
     colorThemeOptions,
     colorThemeDefault,
+    formStatusOptions,
+    formStatusDefault,
     spaceOptions,
     spaceDefault,
+    iconSizeOptions,
 } from '../../shared/constants';
 import { IconLabelBase } from './style';
 
-const IconLabel = props => {
-    return <IconLabelBase {...props}>{props.children}</IconLabelBase>;
+const IconLabel = ({ icon, children, ...rest }) => {
+    return (
+        <IconLabelBase {...rest}>
+            {icon
+                ? React.cloneElement(icon, {
+                      colorPallet: rest.colorPallet,
+                      colorTheme: rest.colorTheme,
+                      colorStatus: rest.colorStatus,
+                      iconSize: iconSizeOptions.xs,
+                      marginRight: spaceOptions.xs,
+                  })
+                : null}
+
+            {children}
+        </IconLabelBase>
+    );
 };
 
 IconLabel.propTypes = {
+    icon: PropTypes.element,
+    colorPallet: PropTypes.oneOf([
+        colorPalletOptions.theme,
+        colorPalletOptions.status,
+    ]),
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
+    colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)),
     marginTop: PropTypes.oneOf(Object.values(spaceOptions)),
     marginBottom: PropTypes.oneOf(Object.values(spaceOptions)),
     marginLeft: PropTypes.oneOf(Object.values(spaceOptions)),
@@ -21,7 +46,10 @@ IconLabel.propTypes = {
 };
 
 IconLabel.defaultProps = {
+    icon: null,
+    colorPallet: colorPalletDefault,
     colorTheme: colorThemeDefault,
+    colorStatus: formStatusDefault,
     marginTop: spaceDefault,
     marginBottom: spaceDefault,
     marginLeft: spaceDefault,

--- a/src/lib/IconLabel/IconLabel.stories.js
+++ b/src/lib/IconLabel/IconLabel.stories.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { withKnobs, text, select, radios } from '@storybook/addon-knobs';
 import {
     folder,
+    colorPalletOptions,
+    colorPalletDefault,
     colorThemeOptions,
     colorThemeDefault,
+    formStatusOptions,
+    formStatusDefault,
     spaceOptions,
     spaceDefault,
     iconSizeOptions,
@@ -13,14 +17,26 @@ import labels from '../../shared/labels';
 import { OutIcon } from '../Icon/Icon';
 import IconLabel from './IconLabel';
 
+const { wab, ...buttonColorPalletOptions } = colorPalletOptions;
+
 storiesOf(folder.text + 'IconLabel', module)
     .addDecorator(withKnobs)
     .add('IconLabel', () => (
         <IconLabel
+            colorPallet={radios(
+                labels.colorPallet,
+                buttonColorPalletOptions,
+                colorPalletDefault,
+            )}
             colorTheme={select(
                 labels.colorTheme,
                 colorThemeOptions,
                 colorThemeDefault,
+            )}
+            colorStatus={select(
+                labels.colorStatus,
+                formStatusOptions,
+                formStatusDefault,
             )}
             marginTop={select(labels.marginTop, spaceOptions, spaceDefault)}
             marginBottom={select(
@@ -30,17 +46,8 @@ storiesOf(folder.text + 'IconLabel', module)
             )}
             marginLeft={select(labels.marginLeft, spaceOptions, spaceDefault)}
             marginRight={select(labels.marginRight, spaceOptions, spaceDefault)}
+            icon={<OutIcon />}
         >
-            <OutIcon
-                iconSize={iconSizeOptions.xs}
-                marginRight={spaceOptions.xs}
-                colorTheme={select(
-                    labels.colorTheme,
-                    colorThemeOptions,
-                    colorThemeDefault,
-                )}
-            />
-
             {text(labels.text, 'Sample')}
         </IconLabel>
     ));

--- a/src/lib/IconLabel/IconLabel.test.js
+++ b/src/lib/IconLabel/IconLabel.test.js
@@ -1,26 +1,14 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { ThemeDefault } from '../../theme';
-import {
-    spaceOptions,
-    iconSizeOptions
-} from '../../shared/constants';
 import { OutIcon } from '../Icon/Icon';
 import IconLabel from './IconLabel';
 
 it('renders without crashing', () => {
     const iconLabel = TestRenderer.create(
-        <IconLabel
-            theme={ThemeDefault}
-        >
-            <OutIcon
-                theme={ThemeDefault}
-                iconSize={iconSizeOptions.xs}
-                marginRight={spaceOptions.xs}
-            />
-
+        <IconLabel theme={ThemeDefault} icon={<OutIcon theme={ThemeDefault} />}>
             Label text
-        </IconLabel>
+        </IconLabel>,
     );
     expect(iconLabel.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/IconLabel/__snapshots__/IconLabel.test.js.snap
+++ b/src/lib/IconLabel/__snapshots__/IconLabel.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <span
-  className="style__IconLabelBase-sc-113x6jx-0 fZXecA"
+  className="style__IconLabelBase-sc-113x6jx-0 Vhqks"
 >
   <span
     className="style__IconBase-ak3679-0 cYreIg icon"

--- a/src/lib/IconLabel/style/base.js
+++ b/src/lib/IconLabel/style/base.js
@@ -1,0 +1,15 @@
+import { css } from 'styled-components';
+
+const colorStyle = {
+    theme: css`
+        background-color: ${props => props.theme.color[props.colorTheme].light};
+        color: ${props => props.theme.color[props.colorTheme].main};
+    `,
+    status: css`
+        background-color: ${props =>
+            props.theme.status[props.colorStatus].light};
+        color: ${props => props.theme.status[props.colorStatus].main};
+    `,
+};
+
+export { colorStyle };

--- a/src/lib/IconLabel/style/index.js
+++ b/src/lib/IconLabel/style/index.js
@@ -1,17 +1,18 @@
 import styled from 'styled-components';
 import { directionalProperty } from 'polished';
+import { colorStyle } from './base';
 
 const IconLabelBase = styled.span`
     display: inline-flex;
     align-items: center;
     border-radius: ${props => props.theme.radius.sm};
-    background-color: ${props => props.theme.color[props.colorTheme].light};
-    color: ${props => props.theme.color[props.colorTheme].main};
     padding: ${props => props.theme.space.xs};
     text-transform: uppercase;
     font-size: ${props => props.theme.font.size.tiny};
     font-weight: ${props => props.theme.font.weight.bold};
     letter-spacing: ${props => props.theme.font.spacing};
+
+    ${props => colorStyle[props.colorPallet]};
 
     ${props => directionalProperty('margin',
         props.theme.space[props.marginTop],

--- a/src/lib/Menu/Menu.stories.js
+++ b/src/lib/Menu/Menu.stories.js
@@ -6,7 +6,6 @@ import {
     colorThemeOptions,
     colorThemeDefault,
     iconSizeOptions,
-    spaceOptions,
 } from '../../shared/constants';
 import labels from '../../shared/labels';
 import { LeafIcon, CardsIcon, OrganizationIcon, OutIcon } from '../Icon/Icon';
@@ -110,16 +109,8 @@ storiesOf(folder.nav + folder.sub.menu + 'Menu', module)
                                 colorThemeOptions,
                                 colorThemeDefault,
                             )}
+                            icon={<OutIcon />}
                         >
-                            <OutIcon
-                                iconSize={iconSizeOptions.xs}
-                                marginRight={spaceOptions.xs}
-                                colorTheme={select(
-                                    labels.colorTheme,
-                                    colorThemeOptions,
-                                    colorThemeDefault,
-                                )}
-                            />
                             Dev
                         </IconLabel>
                     </MenuListItem>

--- a/src/lib/MenuGroup/MenuGroup.stories.js
+++ b/src/lib/MenuGroup/MenuGroup.stories.js
@@ -108,11 +108,7 @@ storiesOf(folder.nav + 'MenuGroup', module)
 
                                     <Link>Payment</Link>
 
-                                    <IconLabel>
-                                        <OutIcon
-                                            iconSize={iconSizeOptions.xs}
-                                            marginRight={spaceOptions.xs}
-                                        />
+                                    <IconLabel icon={<OutIcon />}>
                                         Dev
                                     </IconLabel>
                                 </MenuListItem>
@@ -155,11 +151,7 @@ storiesOf(folder.nav + 'MenuGroup', module)
 
                                     <Link>Payment</Link>
 
-                                    <IconLabel>
-                                        <OutIcon
-                                            iconSize={iconSizeOptions.xs}
-                                            marginRight={spaceOptions.xs}
-                                        />
+                                    <IconLabel icon={<OutIcon />}>
                                         Dev
                                     </IconLabel>
                                 </MenuListItem>

--- a/src/lib/MenuList/MenuList.stories.js
+++ b/src/lib/MenuList/MenuList.stories.js
@@ -6,7 +6,6 @@ import {
     colorThemeDefault,
     colorThemeOptions,
     iconSizeOptions,
-    spaceOptions,
 } from '../../shared/constants';
 import labels from '../../shared/labels';
 import {
@@ -63,12 +62,7 @@ storiesOf(folder.nav + folder.sub.menu + 'MenuList', module)
 
                         <Link colorTheme={color[1]}>Payment</Link>
 
-                        <IconLabel colorTheme={color[1]}>
-                            <OutIcon
-                                iconSize={iconSizeOptions.xs}
-                                marginRight={spaceOptions.xs}
-                                colorTheme={color[1]}
-                            />
+                        <IconLabel colorTheme={color[1]} icon={<OutIcon />}>
                             Dev
                         </IconLabel>
                     </MenuListItem>
@@ -83,12 +77,7 @@ storiesOf(folder.nav + folder.sub.menu + 'MenuList', module)
 
                         <Link colorTheme={color[2]}>Lunchkit</Link>
 
-                        <IconLabel colorTheme={color[2]}>
-                            <OutIcon
-                                iconSize={iconSizeOptions.xs}
-                                marginRight={spaceOptions.xs}
-                                colorTheme={color[2]}
-                            />
+                        <IconLabel colorTheme={color[2]} icon={<OutIcon />}>
                             Dev
                         </IconLabel>
 

--- a/src/lib/MenuListItem/MenuListItem.stories.js
+++ b/src/lib/MenuListItem/MenuListItem.stories.js
@@ -7,7 +7,6 @@ import {
     colorThemeOptions,
     colorThemeDefault,
     iconSizeOptions,
-    spaceOptions,
 } from '../../shared/constants';
 import labels from '../../shared/labels';
 import { CardsIcon, OutIcon } from '../Icon/Icon';
@@ -52,16 +51,8 @@ storiesOf(folder.nav + folder.sub.menu + 'MenuListItem', module)
                         colorThemeOptions,
                         colorThemeDefault,
                     )}
+                    icon={<OutIcon />}
                 >
-                    <OutIcon
-                        iconSize={iconSizeOptions.xs}
-                        marginRight={spaceOptions.xs}
-                        colorTheme={select(
-                            labels.colorTheme,
-                            colorThemeOptions,
-                            colorThemeDefault,
-                        )}
-                    />
                     Dev
                 </IconLabel>
 
@@ -95,16 +86,8 @@ storiesOf(folder.nav + folder.sub.menu + 'MenuListItem', module)
                         colorThemeOptions,
                         colorThemeDefault,
                     )}
+                    icon={<OutIcon />}
                 >
-                    <OutIcon
-                        iconSize={iconSizeOptions.xs}
-                        marginRight={spaceOptions.xs}
-                        colorTheme={select(
-                            labels.colorTheme,
-                            colorThemeOptions,
-                            colorThemeDefault,
-                        )}
-                    />
                     Dev
                 </IconLabel>
 

--- a/src/lib/MenuListItem/MenuListItem.test.js
+++ b/src/lib/MenuListItem/MenuListItem.test.js
@@ -16,12 +16,10 @@ it('renders without crashing', () => {
 
                 <Link theme={ThemeDefault}>Payment</Link>
 
-                <IconLabel theme={ThemeDefault}>
-                    <OutIcon
-                        theme={ThemeDefault}
-                        iconSize={iconSizeOptions.xs}
-                        marginRight={spaceOptions.xs}
-                    />
+                <IconLabel
+                    theme={ThemeDefault}
+                    icon={<OutIcon theme={ThemeDefault} />}
+                >
                     Dev
                 </IconLabel>
 

--- a/src/lib/MenuListItem/__snapshots__/MenuListItem.test.js.snap
+++ b/src/lib/MenuListItem/__snapshots__/MenuListItem.test.js.snap
@@ -31,7 +31,7 @@ exports[`renders without crashing 1`] = `
       Payment
     </span>
     <span
-      className="style__IconLabelBase-sc-113x6jx-0 fZXecA"
+      className="style__IconLabelBase-sc-113x6jx-0 Vhqks"
     >
       <span
         className="style__IconBase-ak3679-0 cYreIg icon"

--- a/src/lib/MenuPrimary/MenuPrimary.stories.js
+++ b/src/lib/MenuPrimary/MenuPrimary.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
-import { folder, iconSizeOptions, spaceOptions } from '../../shared/constants';
+import { folder, iconSizeOptions } from '../../shared/constants';
 import labels from '../../shared/labels';
 import { LeafIcon, CardsIcon, OrganizationIcon, OutIcon } from '../Icon/Icon';
 import Link from '../Link/Link';
@@ -47,13 +47,7 @@ storiesOf(folder.nav + 'MenuPrimary', module)
 
                             <Link>Payment</Link>
 
-                            <IconLabel>
-                                <OutIcon
-                                    iconSize={iconSizeOptions.xs}
-                                    marginRight={spaceOptions.xs}
-                                />
-                                Dev
-                            </IconLabel>
+                            <IconLabel icon={<OutIcon />}>Dev</IconLabel>
                         </MenuListItem>
                     </a>
 
@@ -91,13 +85,7 @@ storiesOf(folder.nav + 'MenuPrimary', module)
 
                             <Link>Payment</Link>
 
-                            <IconLabel>
-                                <OutIcon
-                                    iconSize={iconSizeOptions.xs}
-                                    marginRight={spaceOptions.xs}
-                                />
-                                Dev
-                            </IconLabel>
+                            <IconLabel icon={<OutIcon />}>Dev</IconLabel>
                         </MenuListItem>
                     </a>
 

--- a/src/lib/MenuPrimary/MenuPrimary.test.js
+++ b/src/lib/MenuPrimary/MenuPrimary.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { ThemeDefault } from '../../theme';
-import { iconSizeOptions, spaceOptions } from '../../shared/constants';
+import { iconSizeOptions } from '../../shared/constants';
 import { LeafIcon, CardsIcon, OutIcon } from '../Icon/Icon';
 import Link from '../Link/Link';
 import IconLabel from '../IconLabel/IconLabel';
@@ -53,12 +53,10 @@ it('renders without crashing', () => {
 
                             <Link theme={ThemeDefault}>Payment</Link>
 
-                            <IconLabel theme={ThemeDefault}>
-                                <OutIcon
-                                    iconSize={iconSizeOptions.xs}
-                                    marginRight={spaceOptions.xs}
-                                    theme={ThemeDefault}
-                                />
+                            <IconLabel
+                                theme={ThemeDefault}
+                                icon={<OutIcon theme={ThemeDefault} />}
+                            >
                                 Dev
                             </IconLabel>
                         </MenuListItem>

--- a/src/lib/MenuPrimary/__snapshots__/MenuPrimary.test.js.snap
+++ b/src/lib/MenuPrimary/__snapshots__/MenuPrimary.test.js.snap
@@ -91,7 +91,7 @@ exports[`renders without crashing 1`] = `
               Payment
             </span>
             <span
-              className="style__IconLabelBase-sc-113x6jx-0 fZXecA"
+              className="style__IconLabelBase-sc-113x6jx-0 Vhqks"
             >
               <span
                 className="style__IconBase-ak3679-0 cYreIg icon"


### PR DESCRIPTION
Ce qui a été fait
------

- Autoriser le passage de l'icon dans une props `icon` (optionnelle) sur le **IconLabel** : l'ancienne intégration reste valable, mais celle-ci permet de ne pas gérer les couleurs et tailles d'icons.
- Ajout du `colorPallet` `status`
- Refacto des stories et tests de composants embarquant des **IconLabel**

Comment tester
------

- Tester les couleurs sur la storie de l'IconLabel et vérifier qu'il n'y a pas d'erreur en console
- Afficher les stories des composants Menu, MenuList, MenuListItem, MenuPrimary et MenuGroup et vérifier qu'il n'y a pas d'erreur en console et que les IconLabel ont des couleurs cohérentes (genre pas un icon rouge dans un label vert)
