### PR TITLE
PGF-1005: prise en compte du defaultValue sur Textarea et DaTextarea

### DIFF
--- a/src/lib/DaTextarea/DaTextarea.js
+++ b/src/lib/DaTextarea/DaTextarea.js
@@ -14,6 +14,7 @@ const DaTextarea = ({
     theme,
     onChange,
     value,
+    defaultValue,
     hasCounter,
     counterText,
     marginTop,
@@ -25,7 +26,7 @@ const DaTextarea = ({
     inputRef,
     ...rest
 }) => {
-    const [stateValue, setValue] = useState(value);
+    const [stateValue, setValue] = useState(defaultValue || value);
     const [autoHeight, setAutoHeight] = useState('');
     const [stateCharactersStatus, setCharactersStatus] = useState(
         formStatusDefault,

--- a/src/lib/GlobalStyle/ResetStyle.js
+++ b/src/lib/GlobalStyle/ResetStyle.js
@@ -9,6 +9,11 @@ export const ResetStyle = css`
         font-size: 62.5%;
     }
 
+    body {
+        word-break: break-word; // deprecated but usefull CSS property (replaced by less usefull overflow-wrap property)
+        overflow-wrap: break-word;
+    }
+
     body,
     main,
     header,

--- a/src/lib/Textarea/Textarea.js
+++ b/src/lib/Textarea/Textarea.js
@@ -11,6 +11,7 @@ const Textarea = ({
     theme,
     onChange,
     value,
+    defaultValue,
     status,
     label,
     hasCounter,
@@ -21,7 +22,7 @@ const Textarea = ({
     marginBottom,
     ...rest
 }) => {
-    const [stateValue, setValue] = useState(value);
+    const [stateValue, setValue] = useState(defaultValue || value);
     const [stateCharactersStatus, setCharactersStatus] = useState(
         formStatusDefault,
     );


### PR DESCRIPTION
- Prise en compte du `defaultValue` sur les composants **Textarea** et **DaTextarea** : si on définit une `defaultValue`, elle sera bien prise en compte (au même titre que la `value`) et il n'y aura plus d'erreur en console
- Ajout d'un bout de CSS pour couper les mots longs (genre `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` merci Maxime ~~de nous emmerder~~ pour son aide) sur l'ensemble des composants 👌 