### PR TITLE
PGF-1010: permettre de customiser les couleurs du Toggle

### DIFF
--- a/src/lib/Toggle/Toggle.js
+++ b/src/lib/Toggle/Toggle.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+    buttonSizeOptions,
+    buttonSizeDefault,
     colorPalletOptions,
     colorThemeOptions,
     colorThemeDefault,
@@ -15,6 +17,7 @@ const Toggle = ({
     theme,
     checkedLabel,
     notCheckedLabel,
+    fieldSize,
     colorPallet,
     colorTheme,
     colorWab,
@@ -55,6 +58,7 @@ const Toggle = ({
         <ToggleBase
             theme={theme} // not necessary, only needed for tests
             isDisabled={rest.disabled}
+            fieldSize={fieldSize}
             checkedColor={checkedLabelProps}
             notCheckedColor={notCheckedLabelProps}
         >
@@ -62,6 +66,7 @@ const Toggle = ({
 
             <ToggleElement
                 theme={theme} // not necessary, only needed for tests
+                fieldSize={fieldSize}
             >
                 <ToggleLabel
                     theme={theme} // not necessary, only needed for tests
@@ -85,6 +90,7 @@ Toggle.propTypes = {
     disabled: PropTypes.bool,
     checkedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     notCheckedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    fieldSize: PropTypes.oneOf(Object.values(buttonSizeOptions)),
     colorPallet: PropTypes.oneOfType([
         PropTypes.oneOf(Object.values(colorPalletOptions)),
         PropTypes.shape({
@@ -117,6 +123,7 @@ Toggle.propTypes = {
 
 Toggle.defaultProps = {
     disabled: false,
+    fieldSize: buttonSizeDefault,
     colorPallet: colorPalletOptions.status,
     colorTheme: colorThemeDefault,
     colorWab: greyDefault,

--- a/src/lib/Toggle/Toggle.js
+++ b/src/lib/Toggle/Toggle.js
@@ -8,62 +8,111 @@ import {
     greyDefault,
     formStatusOptions,
 } from '../../shared/constants';
-import { ToggleBase } from './style';
+import { ToggleElement, ToggleBase } from './style';
+import ToggleLabel from './ToggleLabel';
 
 const Toggle = ({
     theme,
     checkedLabel,
     notCheckedLabel,
-    children,
     colorPallet,
     colorTheme,
     colorWab,
     colorStatus,
     ...rest
 }) => {
+    const checkedLabelProps = {
+        colorPallet:
+            typeof colorPallet === 'object'
+                ? colorPallet.checked
+                : colorPallet === colorPalletOptions.wab
+                ? colorPalletOptions.status
+                : colorPallet,
+        colorTheme:
+            typeof colorTheme === 'object' ? colorTheme.checked : colorTheme,
+        colorWab: typeof colorWab === 'object' ? colorWab.checked : colorWab,
+        colorStatus:
+            typeof colorStatus === 'object' ? colorStatus.checked : colorStatus,
+    };
+
+    const notCheckedLabelProps = {
+        colorPallet:
+            typeof colorPallet === 'object'
+                ? colorPallet.notChecked
+                : colorPallet === colorPalletOptions.status
+                ? colorPallet
+                : colorPalletOptions.wab,
+        colorTheme:
+            typeof colorTheme === 'object' ? colorTheme.notChecked : colorTheme,
+        colorWab: typeof colorWab === 'object' ? colorWab.notChecked : colorWab,
+        colorStatus:
+            typeof colorStatus === 'object'
+                ? colorStatus.notChecked
+                : formStatusOptions.danger,
+    };
+
     return (
         <ToggleBase
             theme={theme} // not necessary, only needed for tests
-            colorPallet={colorPallet}
-            colorTheme={colorTheme}
-            colorWab={colorWab}
-            colorStatus={colorStatus}
             isDisabled={rest.disabled}
+            checkedColor={checkedLabelProps}
+            notCheckedColor={notCheckedLabelProps}
         >
-            {children ? <span className="legend">{children}</span> : null}
+            <input {...rest} type="checkbox" />
 
-            <label htmlFor={rest.id}>
-                <input {...rest} type="checkbox" />
+            <ToggleElement
+                theme={theme} // not necessary, only needed for tests
+            >
+                <ToggleLabel
+                    theme={theme} // not necessary, only needed for tests
+                    {...checkedLabelProps}
+                >
+                    {checkedLabel}
+                </ToggleLabel>
 
-                <div className="toggle">
-                    <span className="checked-label">
-                        {checkedLabel || null}
-                    </span>
-
-                    <span className="not-checked-label">
-                        {notCheckedLabel || null}
-                    </span>
-                </div>
-            </label>
+                <ToggleLabel
+                    theme={theme} // not necessary, only needed for tests
+                    {...notCheckedLabelProps}
+                >
+                    {notCheckedLabel}
+                </ToggleLabel>
+            </ToggleElement>
         </ToggleBase>
     );
 };
 
 Toggle.propTypes = {
-    id: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
-    checkedLabel:  PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element,
+    checkedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    notCheckedLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    colorPallet: PropTypes.oneOfType([
+        PropTypes.oneOf(Object.values(colorPalletOptions)),
+        PropTypes.shape({
+            checked: PropTypes.oneOf(Object.values(colorPalletOptions)),
+            notChecked: PropTypes.oneOf(Object.values(colorPalletOptions)),
+        }),
     ]),
-    notCheckedLabel: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element,
+    colorTheme: PropTypes.oneOfType([
+        PropTypes.oneOf(Object.values(colorThemeOptions)),
+        PropTypes.shape({
+            checked: PropTypes.oneOf(Object.values(colorThemeOptions)),
+            notChecked: PropTypes.oneOf(Object.values(colorThemeOptions)),
+        }),
     ]),
-    colorPallet: PropTypes.oneOf(Object.values(colorPalletOptions)),
-    colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
-    colorWab: PropTypes.oneOf(Object.values(greyOptions)),
-    colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)),
+    colorWab: PropTypes.oneOfType([
+        PropTypes.oneOf(Object.values(greyOptions)),
+        PropTypes.shape({
+            checked: PropTypes.oneOf(Object.values(greyOptions)),
+            notChecked: PropTypes.oneOf(Object.values(greyOptions)),
+        }),
+    ]),
+    colorStatus: PropTypes.oneOfType([
+        PropTypes.oneOf(Object.values(formStatusOptions)),
+        PropTypes.shape({
+            checked: PropTypes.oneOf(Object.values(formStatusOptions)),
+            notChecked: PropTypes.oneOf(Object.values(formStatusOptions)),
+        }),
+    ]),
 };
 
 Toggle.defaultProps = {

--- a/src/lib/Toggle/Toggle.stories.js
+++ b/src/lib/Toggle/Toggle.stories.js
@@ -9,6 +9,8 @@ import {
 } from '@storybook/addon-knobs';
 import {
     folder,
+    buttonSizeOptions,
+    buttonSizeDefault,
     colorPalletOptions,
     colorThemeOptions,
     colorThemeDefault,
@@ -27,6 +29,11 @@ storiesOf(folder.form + 'Toggle', module)
             disabled={boolean(labels.disabled, false)}
             checkedLabel={text('Checked label', 'Yes')}
             notCheckedLabel={text('Not checked label', 'No')}
+            fieldSize={select(
+                labels.fieldSize,
+                buttonSizeOptions,
+                buttonSizeDefault,
+            )}
             colorPallet={radios(
                 labels.colorPallet,
                 colorPalletOptions,

--- a/src/lib/Toggle/Toggle.stories.js
+++ b/src/lib/Toggle/Toggle.stories.js
@@ -22,10 +22,11 @@ import Toggle from './Toggle';
 
 storiesOf(folder.form + 'Toggle', module)
     .addDecorator(withKnobs)
-    .add('Toggle simple', () => (
+    .add('Toggle', () => (
         <Toggle
-            id="toggle1"
             disabled={boolean(labels.disabled, false)}
+            checkedLabel={text('Checked label', 'Yes')}
+            notCheckedLabel={text('Not checked label', 'No')}
             colorPallet={radios(
                 labels.colorPallet,
                 colorPalletOptions,
@@ -46,51 +47,56 @@ storiesOf(folder.form + 'Toggle', module)
     ))
     .add('Toggle with icons', () => (
         <Toggle
-            id="toggle2"
+            disabled={boolean(labels.disabled, false)}
             checkedLabel={<BulbIcon />}
             notCheckedLabel={<BeakerIcon />}
-            disabled={boolean(labels.disabled, false)}
-            colorPallet={radios(
-                labels.colorPallet,
-                colorPalletOptions,
-                colorPalletOptions.status,
-            )}
-            colorTheme={select(
-                labels.colorTheme,
-                colorThemeOptions,
-                colorThemeDefault,
-            )}
-            colorWab={select(labels.colorWab, greyOptions, greyDefault)}
-            colorStatus={select(
-                labels.colorStatus,
-                formStatusOptions,
-                formStatusOptions.success,
-            )}
+            colorPallet={{
+                checked: select(
+                    labels.colorPallet + ' checked',
+                    colorPalletOptions,
+                    colorPalletOptions.status,
+                ),
+                notChecked: select(
+                    labels.colorPallet + ' not checked',
+                    colorPalletOptions,
+                    colorPalletOptions.wab,
+                ),
+            }}
+            colorTheme={{
+                checked: select(
+                    labels.colorTheme + ' checked',
+                    colorThemeOptions,
+                    colorThemeDefault,
+                ),
+                notChecked: select(
+                    labels.colorTheme + ' not checked',
+                    colorThemeOptions,
+                    colorThemeDefault,
+                ),
+            }}
+            colorWab={{
+                checked: select(
+                    labels.colorWab + ' checked',
+                    greyOptions,
+                    greyDefault,
+                ),
+                notChecked: select(
+                    labels.colorWab + ' not checked',
+                    greyOptions,
+                    greyDefault,
+                ),
+            }}
+            colorStatus={{
+                checked: select(
+                    labels.colorStatus + ' checked',
+                    formStatusOptions,
+                    formStatusOptions.success,
+                ),
+                notChecked: select(
+                    labels.colorStatus + ' not checked',
+                    formStatusOptions,
+                    formStatusOptions.danger,
+                ),
+            }}
         />
-    ))
-    .add('Toggle with texts', () => (
-        <Toggle
-            id="toggle3"
-            disabled={boolean(labels.disabled, false)}
-            checkedLabel={text('Checked label', 'Yes')}
-            notCheckedLabel={text('Not checked label', 'No')}
-            colorPallet={radios(
-                labels.colorPallet,
-                colorPalletOptions,
-                colorPalletOptions.status,
-            )}
-            colorTheme={select(
-                labels.colorTheme,
-                colorThemeOptions,
-                colorThemeDefault,
-            )}
-            colorWab={select(labels.colorWab, greyOptions, greyDefault)}
-            colorStatus={select(
-                labels.colorStatus,
-                formStatusOptions,
-                formStatusOptions.success,
-            )}
-        >
-            Label text
-        </Toggle>
     ));

--- a/src/lib/Toggle/Toggle.stories.js
+++ b/src/lib/Toggle/Toggle.stories.js
@@ -24,7 +24,7 @@ import Toggle from './Toggle';
 
 storiesOf(folder.form + 'Toggle', module)
     .addDecorator(withKnobs)
-    .add('Toggle', () => (
+    .add('Toggle with auto colors', () => (
         <Toggle
             disabled={boolean(labels.disabled, false)}
             checkedLabel={text('Checked label', 'Yes')}
@@ -52,7 +52,7 @@ storiesOf(folder.form + 'Toggle', module)
             )}
         />
     ))
-    .add('Toggle with icons', () => (
+    .add('Toggle with custom colors', () => (
         <Toggle
             disabled={boolean(labels.disabled, false)}
             checkedLabel={<BulbIcon />}

--- a/src/lib/Toggle/Toggle.test.js
+++ b/src/lib/Toggle/Toggle.test.js
@@ -5,7 +5,7 @@ import Toggle from './Toggle';
 
 it('renders without crashing', () => {
     const component = TestRenderer.create(
-        <Toggle theme={ThemeDefault} id="toggle-test" />
+        <Toggle theme={ThemeDefault} />
     );
     expect(component.toJSON()).toMatchSnapshot();
 });

--- a/src/lib/Toggle/ToggleLabel.js
+++ b/src/lib/Toggle/ToggleLabel.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    colorPalletOptions,
+    colorThemeOptions,
+    greyOptions,
+    formStatusOptions,
+} from '../../shared/constants';
+import { ToggleLabelBase } from './style';
+
+const ToggleLabel = ({ children, ...rest }) => {
+    return (
+        <ToggleLabelBase {...rest}>
+            {React.Children.map(children, (child, index) => {
+                if (!child) {
+                    return null;
+                }
+
+                if (typeof child === 'object') {
+                    return React.cloneElement(child, {
+                        colorPallet: rest.colorPallet,
+                        colorTheme: rest.colorTheme,
+                        colorWab: rest.colorWab,
+                        colorStatus: rest.colorStatus,
+                        key: index,
+                    });
+                }
+
+                return child;
+            })}
+        </ToggleLabelBase>
+    );
+};
+
+ToggleLabel.propTypes = {
+    colorPallet: PropTypes.oneOf(Object.values(colorPalletOptions)).isRequired,
+    colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)).isRequired,
+    colorWab: PropTypes.oneOf(Object.values(greyOptions)).isRequired,
+    colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)).isRequired,
+};
+
+export default ToggleLabel;

--- a/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
+++ b/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`renders without crashing 1`] = `
 <label
-  className="style__ToggleBase-gnd37d-2 jbsWWl"
+  className="style__ToggleBase-gnd37d-2 yLNSl"
 >
   <input
     disabled={false}
     type="checkbox"
   />
   <div
-    className="style__ToggleElement-gnd37d-1 ekNmJQ"
+    className="style__ToggleElement-gnd37d-1 dbJCDi"
   >
     <div
-      className="style__ToggleLabelBase-gnd37d-0 kSsTCp"
+      className="style__ToggleLabelBase-gnd37d-0 jfGDSz"
     />
     <div
-      className="style__ToggleLabelBase-gnd37d-0 kSsTCp"
+      className="style__ToggleLabelBase-gnd37d-0 jfGDSz"
     />
   </div>
 </label>

--- a/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
+++ b/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
@@ -12,10 +12,10 @@ exports[`renders without crashing 1`] = `
     className="style__ToggleElement-gnd37d-1 dbJCDi"
   >
     <div
-      className="style__ToggleLabelBase-gnd37d-0 jfGDSz"
+      className="style__ToggleLabelBase-gnd37d-0 kLVWfn"
     />
     <div
-      className="style__ToggleLabelBase-gnd37d-0 jfGDSz"
+      className="style__ToggleLabelBase-gnd37d-0 kLVWfn"
     />
   </div>
 </label>

--- a/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
+++ b/src/lib/Toggle/__snapshots__/Toggle.test.js.snap
@@ -1,27 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders without crashing 1`] = `
-<div
-  className="style__ToggleBase-gnd37d-0 kGpEaJ"
+<label
+  className="style__ToggleBase-gnd37d-2 jbsWWl"
 >
-  <label
-    htmlFor="toggle-test"
+  <input
+    disabled={false}
+    type="checkbox"
+  />
+  <div
+    className="style__ToggleElement-gnd37d-1 ekNmJQ"
   >
-    <input
-      disabled={false}
-      id="toggle-test"
-      type="checkbox"
+    <div
+      className="style__ToggleLabelBase-gnd37d-0 kSsTCp"
     />
     <div
-      className="toggle"
-    >
-      <span
-        className="checked-label"
-      />
-      <span
-        className="not-checked-label"
-      />
-    </div>
-  </label>
-</div>
+      className="style__ToggleLabelBase-gnd37d-0 kSsTCp"
+    />
+  </div>
+</label>
 `;

--- a/src/lib/Toggle/style/constants.js
+++ b/src/lib/Toggle/style/constants.js
@@ -1,26 +1,34 @@
 const color = {
-    main: {
-        base: {
-            theme: props => props.theme.wab[props.colorWab],
-            wab: props => props.theme.wab[props.colorWab],
-            status: props => props.theme.status.danger.main,
+    checked: {
+        main: {
+            theme: props =>
+                props.theme.color[props.checkedColor.colorTheme].main,
+            wab: props => props.theme.wab[props.checkedColor.colorWab],
+            status: props =>
+                props.theme.status[props.checkedColor.colorStatus].main,
         },
-        checked: {
-            theme: props => props.theme.color[props.colorTheme].main,
-            wab: props => props.theme.status[props.colorStatus].main,
-            status: props => props.theme.status[props.colorStatus].main,
+        bg: {
+            theme: props =>
+                props.theme.color[props.checkedColor.colorTheme].light,
+            wab: props => props.theme.wab.grey10,
+            status: props =>
+                props.theme.status[props.checkedColor.colorStatus].light,
         },
     },
-    bg: {
-        base: {
-            theme: props => props.theme.wab.grey10,
-            wab: props => props.theme.wab.grey10,
-            status: props => props.theme.status.danger.light,
+    notChecked: {
+        main: {
+            theme: props =>
+                props.theme.color[props.notCheckedColor.colorTheme].main,
+            wab: props => props.theme.wab[props.notCheckedColor.colorWab],
+            status: props =>
+                props.theme.status[props.notCheckedColor.colorStatus].main,
         },
-        checked: {
-            theme: props => props.theme.color[props.colorTheme].light,
-            wab: props => props.theme.status[props.colorStatus].light,
-            status: props => props.theme.status[props.colorStatus].light,
+        bg: {
+            theme: props =>
+                props.theme.color[props.notCheckedColor.colorTheme].light,
+            wab: props => props.theme.wab.grey10,
+            status: props =>
+                props.theme.status[props.notCheckedColor.colorStatus].light,
         },
     },
 };

--- a/src/lib/Toggle/style/index.js
+++ b/src/lib/Toggle/style/index.js
@@ -3,115 +3,101 @@ import { math } from 'polished';
 import { color } from './constants';
 import { disabledStyle } from './base';
 
-const ToggleBase = styled.div`
+const ToggleLabelBase = styled.div`
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
+    gap: ${props => props.theme.space.xs};
+    font-size: ${props => props.theme.font.size.sm};
+`;
 
-    .legend {
-        margin-right: ${props => props.theme.space.sm};
-        margin-bottom: ${props => props.theme.space.sm};
-        color: ${props => props.theme.wab[props.colorWab]};
+const ToggleElement = styled.div`
+    position: relative;
+    height: ${props => props.theme.form.toggle};
+    min-width: ${props => math(props.theme.form.toggle + '*2')};
+    border-radius: ${props => math(props.theme.form.toggle + '/2')};
+    display: flex;
+    align-items: center;
+    transition: background-color ${props => props.theme.transition.xs};
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        height: 100%;
+        width: ${props => math(props.theme.form.toggle)};
+        border-radius: 50%;
+        border: 3px solid;
+        transition: all ${props => props.theme.transition.xs};
     }
+`;
 
-    label {
-        position: relative;
-        cursor: pointer;
-        display: flex;
-        justify-content: center;
-        align-items: flex-end;
-        height: ${props => props.theme.form.toggle};
-        margin-bottom: ${props => props.theme.space.sm};
+const ToggleBase = styled.label`
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    width: fit-content;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
 
-        ${props => props.isDisabled ? disabledStyle : null};
+    ${props => (props.isDisabled ? disabledStyle : null)};
 
-        input {
-            position: absolute;
+    input {
+        position: absolute;
 
-            &:checked {
-                & + .toggle {
-                    color: ${props => color.main.checked[props.colorPallet]};
+        &:checked {
+            & + ${ToggleElement} {
+                padding-left: ${props => props.theme.space.sm};
+                padding-right: ${props => props.theme.form.toggle};
+                color: ${props =>
+                    color.checked.main[props.checkedColor.colorPallet]};
+                background-color: ${props =>
+                    color.checked.bg[props.checkedColor.colorPallet]};
+
+                &::after {
+                    left: 100%;
+                    transform: translateX(-100%);
+                    border-color: ${props =>
+                        color.checked.bg[props.checkedColor.colorPallet]};
                     background-color: ${props =>
-                        color.bg.checked[props.colorPallet]};
+                        color.checked.main[props.checkedColor.colorPallet]};
+                }
 
-                    .icon {
-                        svg {
-                            fill: ${props =>
-                                color.main.checked[props.colorPallet]};
-                        }
-                    }
-
-                    &::before {
-                        left: 100%;
-                        transform: translateX(-100%);
-                        border-color: ${props =>
-                            color.bg.checked[props.colorPallet]};
-                        background-color: ${props =>
-                            color.main.checked[props.colorPallet]};
-                    }
-
-                    .checked-label {
-                        font-size: ${props => props.theme.font.size.sm};
-                    }
-                    
-                    .not-checked-label {
-                        font-size: 0;
+                ${ToggleLabelBase} {
+                    &:last-of-type {
+                        display: none;
                     }
                 }
             }
         }
 
-        .toggle {
-            position: relative;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            height: 100%;
-            width: 100%;
-            border-radius: ${props => math(props.theme.form.toggle + '/2')};
-            transition: all ${props => props.theme.transition.xs};
-            color: ${props => color.main.base[props.colorPallet]};
-            background-color: ${props => color.bg.base[props.colorPallet]};
-
-            .icon {
-                svg {
-                    fill: ${props => color.main.base[props.colorPallet]};
-                }
-            }
-
-            &::before {
-                content: '';
-                position: absolute;
-                top: 0;
-                left: 0;
-                height: 100%;
-                width: ${props => props.theme.form.toggle};
-                border-radius: 50%;
-                border: solid 3px ${props => color.bg.base[props.colorPallet]};
-                background-color: ${props =>
-                    color.main.base[props.colorPallet]};
-                transition: all ${props => props.theme.transition.xs};
-            }
-
-            .checked-label,
-            .not-checked-label {
-                box-sizing: border-box;
-                display: flex;
-                min-width: ${props => props.theme.form.toggle};
-            }
-            
-            .checked-label {
-                font-size: 0;
-                padding-left: ${props => props.theme.space.sm};
-            }
-            
-            .not-checked-label {
-                font-size: ${props => props.theme.font.size.sm};
+        &:not(:checked) {
+            & + ${ToggleElement} {
+                padding-left: ${props => props.theme.form.toggle};
                 padding-right: ${props => props.theme.space.sm};
-                text-align: right;
+                color: ${props =>
+                    color.notChecked.main[props.notCheckedColor.colorPallet]};
+                background-color: ${props =>
+                    color.notChecked.bg[props.notCheckedColor.colorPallet]};
+
+                &::after {
+                    left: 0;
+                    border-color: ${props =>
+                        color.notChecked.bg[props.notCheckedColor.colorPallet]};
+                    background-color: ${props =>
+                        color.notChecked.main[
+                            props.notCheckedColor.colorPallet
+                        ]};
+                }
+
+                ${ToggleLabelBase} {
+                    &:first-of-type {
+                        display: none;
+                    }
+                }
             }
         }
     }
 `;
 
-export { ToggleBase };
+export { ToggleLabelBase, ToggleElement, ToggleBase };

--- a/src/lib/Toggle/style/index.js
+++ b/src/lib/Toggle/style/index.js
@@ -4,17 +4,22 @@ import { color } from './constants';
 import { disabledStyle } from './base';
 
 const ToggleLabelBase = styled.div`
+    flex: 1;
     display: flex;
     align-items: center;
     gap: ${props => props.theme.space.xs};
-    font-size: ${props => props.theme.font.size.sm};
+
+    &:last-of-type {
+        justify-content: flex-end;
+    }
 `;
 
 const ToggleElement = styled.div`
     position: relative;
-    height: ${props => props.theme.form.toggle};
-    min-width: ${props => math(props.theme.form.toggle + '*2')};
-    border-radius: ${props => math(props.theme.form.toggle + '/2')};
+    height: ${props => props.theme.form.toggle[props.fieldSize]};
+    min-width: ${props => math(props.theme.form.toggle[props.fieldSize] + '*2')};
+    border-radius: ${props => math(props.theme.form.toggle[props.fieldSize] + '/2')};
+    font-size: ${props => props.theme.daButton.font[props.fieldSize]};
     display: flex;
     align-items: center;
     transition: background-color ${props => props.theme.transition.xs};
@@ -24,9 +29,9 @@ const ToggleElement = styled.div`
         position: absolute;
         top: 0;
         height: 100%;
-        width: ${props => math(props.theme.form.toggle)};
+        width: ${props => props.theme.form.toggle[props.fieldSize]};
         border-radius: 50%;
-        border: 3px solid;
+        border: ${props => props.theme.line} solid;
         transition: all ${props => props.theme.transition.xs};
     }
 `;
@@ -48,7 +53,7 @@ const ToggleBase = styled.label`
         &:checked {
             & + ${ToggleElement} {
                 padding-left: ${props => props.theme.space.sm};
-                padding-right: ${props => props.theme.form.toggle};
+                padding-right: ${props => props.theme.form.toggle[props.fieldSize]};
                 color: ${props =>
                     color.checked.main[props.checkedColor.colorPallet]};
                 background-color: ${props =>
@@ -73,7 +78,7 @@ const ToggleBase = styled.label`
 
         &:not(:checked) {
             & + ${ToggleElement} {
-                padding-left: ${props => props.theme.form.toggle};
+                padding-left: ${props => props.theme.form.toggle[props.fieldSize]};
                 padding-right: ${props => props.theme.space.sm};
                 color: ${props =>
                     color.notChecked.main[props.notCheckedColor.colorPallet]};

--- a/src/lib/Toggle/style/index.js
+++ b/src/lib/Toggle/style/index.js
@@ -7,7 +7,6 @@ const ToggleLabelBase = styled.div`
     flex: 1;
     display: flex;
     align-items: center;
-    gap: ${props => props.theme.space.xs};
 
     &:last-of-type {
         justify-content: flex-end;

--- a/src/theme/theme.base.js
+++ b/src/theme/theme.base.js
@@ -313,7 +313,11 @@ export const ThemeBase = {
             md: '10px',
             lg: '10px',
         },
-        toggle: '30px',
+        toggle: {
+            sm: '24px',
+            md: '28px',
+            lg: '32px',
+        },
     },
     corner: {
         size: {


### PR DESCRIPTION
Ce qui a été fait
-------

- On peut désormais choisir la couleur du disabled du Toggle : pour toutes les props de couleur (`colorPallet`, `colorTheme`, `colorWab` et `colorStatus`), on peut passer soit une string (fonctionnement initial), soit un tableau : 

```
colorPallet={
    checked: 'status',
    notChecked: 'wab
}
```

Si une string est passée, la couleur du disabled sera la même qu'auparavant (ces changements de couleur sont donc totalement rétro-compatibles).

- Ajout d'une props `fieldSize` (`sm`, `md` ou `lg` - `md` par défaut) pour choisir la taille du Toggle. Celui-ci a été un peu réduit dans sa taille par défaut afin de mieux s'intégrer avec d'autres champs.
- La props `legend` a été retirée afin de simplifier le Toggle déjà très complet. Par ailleurs, cela permettra de mieux adapter la taille de la légende en fonction du Toggle. De ce fait, pour garder une légende, il faudra ajouter un composant DaLabel et encapsuler le tout dans une InternalGrid.
- L'`id` n'est plus obligatoire (ça marche sans, donc si on veut en mettre un, c'est possible et ça ira sur l'input, mais sinon on peut s'en passer).

> Note : le CSS et les constantes de couleur sont un peu verbeuses, mais c'est difficile de faire mieux vu le nombre d'options de couleur possibles.

Comment tester
-----

- Allez sur les 2 stories du Toggle et jouez avec les knobs (en particulier les couleurs et la longueur des textes)
- Vérifiez qu'il n'y a pas d'erreur en console