### PR TITLE
PGF-1080: fix multiples sur les DaTable, Modal, DataLegend, CheckboxGroup et DaSelect

### DIFF
--- a/src/colors.stories.mdx
+++ b/src/colors.stories.mdx
@@ -67,6 +67,30 @@ import { ThemeDefault, ThemeDark } from './theme';
       ThemeDefault.color.quinary.gradientShade
     ]}
   />
+
+  <ColorItem
+    title="Senary"
+    subtitle="Main | Light Default | Light Dark | GradientBase | GradientShade"
+    colors={[
+      ThemeDefault.color.senary.main,
+      ThemeDefault.color.senary.light,
+      ThemeDark.color.senary.light,
+      ThemeDefault.color.senary.gradientBase,
+      ThemeDefault.color.senary.gradientShade
+    ]}
+  />
+
+  <ColorItem
+    title="Septenary"
+    subtitle="Main | Light Default | Light Dark | GradientBase | GradientShade"
+    colors={[
+      ThemeDefault.color.septenary.main,
+      ThemeDefault.color.septenary.light,
+      ThemeDark.color.septenary.light,
+      ThemeDefault.color.septenary.gradientBase,
+      ThemeDefault.color.septenary.gradientShade
+    ]}
+  />
 </ColorPalette>
 
 ## Status

--- a/src/lib/CheckboxGroup/CheckboxGroup.js
+++ b/src/lib/CheckboxGroup/CheckboxGroup.js
@@ -34,7 +34,7 @@ const CheckboxGroup = props => {
                     id={props.name + index}
                     value={option.value}
                     label={option.label}
-                    defaultChecked={option.value === value}
+                    defaultChecked={value.includes(option.value)}
                 />
             ))}
         </CheckboxGroupBase>
@@ -42,6 +42,7 @@ const CheckboxGroup = props => {
 };
 
 CheckboxGroup.propTypes = {
+    value: PropTypes.array,
     options: PropTypes.arrayOf(
         PropTypes.shape({
             label: PropTypes.string.isRequired,
@@ -56,6 +57,7 @@ CheckboxGroup.propTypes = {
 };
 
 CheckboxGroup.defaultProps = {
+    value: [],
     fieldSize: buttonSizeDefault,
     disabled: false,
     required: false,

--- a/src/lib/CheckboxGroup/CheckboxGroup.stories.js
+++ b/src/lib/CheckboxGroup/CheckboxGroup.stories.js
@@ -30,7 +30,7 @@ storiesOf(folder.form + folder.sub.checkbox + 'CheckboxGroup', module)
         <CheckboxGroup
             name="checkboxes"
             legend={text(labels.label, 'Checkboxes Label')}
-            value={checkboxOptions[1].value}
+            value={[checkboxOptions[1].value, checkboxOptions[2].value]}
             options={checkboxOptions}
             disabled={boolean(labels.disabled, false)}
             fieldSize={radios(

--- a/src/lib/DaTable/DaTable.stories.js
+++ b/src/lib/DaTable/DaTable.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs';
 import {
@@ -219,47 +219,44 @@ storiesOf(folder.table + folder.sub.daTable + 'DaTable', module)
             <DaTableBody>
                 {!boolean(labels.isLoading, false) &&
                 boolean('With data', true) ? (
-                    sampleRows.map((sample, index) => (
-                        <DaTableRow
-                            key={index}
-                            isActive={
-                                !index ? boolean(labels.isActive, false) : false
-                            }
-                        >
-                            <DaTableCell>
-                                <Checkbox
-                                    id={'checkbox' + index}
-                                    checked={
-                                        !index
-                                            ? boolean(labels.isActive, false)
-                                            : false
-                                    }
-                                    readOnly={true}
-                                />
-                            </DaTableCell>
+                    sampleRows.map((sample, index) => {
+                        const [isActive, setActive] = useState(false);
 
-                            <DaTableCell isId={true}>
-                                {3400 + index}
-                            </DaTableCell>
+                        return (
+                            <DaTableRow key={index} isActive={isActive}>
+                                <DaTableCell>
+                                    <Checkbox
+                                        id={'checkbox' + index}
+                                        onChange={() => setActive(!isActive)}
+                                        checked={isActive}
+                                    />
+                                </DaTableCell>
 
-                            <DaTableCell isMain={false} label="Date">
-                                {sample.date}
-                            </DaTableCell>
+                                <DaTableCell isId={true}>
+                                    {3400 + index}
+                                </DaTableCell>
 
-                            <DaTableCell>{sample.name}</DaTableCell>
+                                <DaTableCell isMain={false} label="Date">
+                                    {sample.date}
+                                </DaTableCell>
 
-                            <DaTableCell>{sample.amount}&nbsp;€</DaTableCell>
+                                <DaTableCell>{sample.name}</DaTableCell>
 
-                            <DaTableCell isMain={false} label="Type">
-                                {sample.type}
-                            </DaTableCell>
+                                <DaTableCell>
+                                    {sample.amount}&nbsp;€
+                                </DaTableCell>
 
-                            <DaTableCell isMain={false} label="Status">
-                                {status.icon[sample.status]}
-                                {status.text[sample.status]}
-                            </DaTableCell>
-                        </DaTableRow>
-                    ))
+                                <DaTableCell isMain={false} label="Type">
+                                    {sample.type}
+                                </DaTableCell>
+
+                                <DaTableCell isMain={false} label="Status">
+                                    {status.icon[sample.status]}
+                                    {status.text[sample.status]}
+                                </DaTableCell>
+                            </DaTableRow>
+                        );
+                    })
                 ) : (
                     <Text
                         textSize={fontSizeOptions.sm}

--- a/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
+++ b/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
@@ -9,10 +9,10 @@ exports[`renders without crashing 1`] = `
   >
     <div
       className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
-      onMouseDown={[Function]}
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -22,6 +22,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 blLFYm cell-main cell-main-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -31,6 +32,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 etkGNS cell-basic cell-basic-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -41,10 +43,10 @@ exports[`renders without crashing 1`] = `
     </div>
     <div
       className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
-      onMouseDown={[Function]}
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -54,6 +56,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 blLFYm cell-main cell-main-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -63,6 +66,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 etkGNS cell-basic cell-basic-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -73,10 +77,10 @@ exports[`renders without crashing 1`] = `
     </div>
     <div
       className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
-      onMouseDown={[Function]}
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -86,6 +90,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 blLFYm cell-main cell-main-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"
@@ -95,6 +100,7 @@ exports[`renders without crashing 1`] = `
       </div>
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 etkGNS cell-basic cell-basic-1"
+        onMouseDown={[Function]}
       >
         <span
           className="cell-content"

--- a/src/lib/DaTableBody/__snapshots__/DaTableBody.test.js.snap
+++ b/src/lib/DaTableBody/__snapshots__/DaTableBody.test.js.snap
@@ -6,10 +6,10 @@ exports[`renders without crashing 1`] = `
 >
   <div
     className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
-    onMouseDown={[Function]}
   >
     <div
       className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"
+      onMouseDown={null}
     >
       <span
         className="cell-content"
@@ -43,6 +43,7 @@ exports[`renders without crashing 1`] = `
     </div>
     <div
       className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
+      onMouseDown={[Function]}
     >
       <span
         className="cell-content"
@@ -52,6 +53,7 @@ exports[`renders without crashing 1`] = `
     </div>
     <div
       className="style__DaTableCellBase-sc-1ed6rma-0 blLFYm cell-main cell-main-1"
+      onMouseDown={[Function]}
     >
       <span
         className="cell-content"
@@ -61,6 +63,7 @@ exports[`renders without crashing 1`] = `
     </div>
     <div
       className="style__DaTableCellBase-sc-1ed6rma-0 etkGNS cell-basic cell-basic-1"
+      onMouseDown={[Function]}
     >
       <span
         className="cell-content"

--- a/src/lib/DaTableHead/__snapshots__/DaTableHead.test.js.snap
+++ b/src/lib/DaTableHead/__snapshots__/DaTableHead.test.js.snap
@@ -27,43 +27,10 @@ exports[`renders without crashing 1`] = `
     </span>
   </div>
   <div
-    className="style__DaTableHeadCellBase-sc-1fpn11j-0 dNVusj"
+    className="style__DaTableHeadCellBase-sc-1fpn11j-0 fcGdZD"
   >
     <div
       className="head-child"
-    >
-      <span
-        className="hideOnBigScreen"
-      >
-        <div
-          className="style__CheckboxBase-sc-1wlk4ud-0 bdkKKN"
-        >
-          <input
-            disabled={false}
-            id="select"
-            type="checkbox"
-          />
-          <label
-            htmlFor="select"
-          >
-            <span
-              className="style__IconBase-ak3679-0 xhyCY icon"
-              type={null}
-            >
-              <svg
-                viewBox="0 0 143 143"
-              >
-                <path
-                  d="M67.1 123c-1.8 0-3.5-.7-4.8-1.9l-48.6-45c-2.8-2.6-3-7.1-.4-9.9 2.6-2.8 7.1-3 9.9-.4l42.6 39.4 52.8-78.5c2.2-3.2 6.5-4.1 9.7-1.9s4.1 6.5 1.9 9.7l-57.4 85.2c-1.1 1.7-3 2.8-5 3-.1.3-.4.3-.7.3z"
-                />
-              </svg>
-            </span>
-          </label>
-        </div>
-      </span>
-    </div>
-    <div
-      className="hideOnSmallScreen"
     >
       <div
         className="style__CheckboxBase-sc-1wlk4ud-0 bdkKKN"
@@ -93,7 +60,7 @@ exports[`renders without crashing 1`] = `
     </div>
   </div>
   <div
-    className="style__DaTableHeadCellBase-sc-1fpn11j-0 bMPZMD"
+    className="style__DaTableHeadCellBase-sc-1fpn11j-0 iMdqdb"
   >
     <div
       className="head-child"
@@ -122,7 +89,7 @@ exports[`renders without crashing 1`] = `
     </div>
   </div>
   <div
-    className="style__DaTableHeadCellBase-sc-1fpn11j-0 bMPZMD"
+    className="style__DaTableHeadCellBase-sc-1fpn11j-0 iMdqdb"
   >
     <div
       className="head-child"

--- a/src/lib/DaTableHeadCell/DaTableHeadCell.js
+++ b/src/lib/DaTableHeadCell/DaTableHeadCell.js
@@ -62,17 +62,11 @@ const DaTableHeadCell = ({
                     </span>
                 ) : null}
 
-                {children && cellIsCheckbox ? (
-                    <span className="hideOnBigScreen">{children}</span>
-                ) : null}
+                {children && cellIsCheckbox ? children : null}
             </div>
 
             {children && !cellIsCheckbox ? (
                 <div className="cell-child">{children}</div>
-            ) : null}
-
-            {children && cellIsCheckbox ? (
-                <div className="hideOnSmallScreen">{children}</div>
             ) : null}
         </DaTableHeadCellBase>
     );

--- a/src/lib/DaTableHeadCell/__snapshots__/DaTableHeadCell.test.js.snap
+++ b/src/lib/DaTableHeadCell/__snapshots__/DaTableHeadCell.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaTableHeadCellBase-sc-1fpn11j-0 bMPZMD"
+  className="style__DaTableHeadCellBase-sc-1fpn11j-0 iMdqdb"
 >
   <div
     className="head-child"

--- a/src/lib/DaTableHeadCell/style/index.js
+++ b/src/lib/DaTableHeadCell/style/index.js
@@ -10,6 +10,7 @@ const DaTableHeadCellBase = styled.div`
 
     @media ${props => props.theme.screen.min.lg} {
         display: table-cell;
+        vertical-align: top;
         padding: 0 ${props => props.theme.space.md};
         padding-bottom: ${props => props.theme.space.sm};
 

--- a/src/lib/DaTableRow/DaTableRow.js
+++ b/src/lib/DaTableRow/DaTableRow.js
@@ -50,17 +50,19 @@ const DaTableRow = props => {
             hasCheckbox={hasCheckbox}
             mainCellCount={mainCellCount}
             notMainCellCount={notMainCellCount}
-            onMouseDown={!isOpen ? () => setOpen(true) : null} // we need to detect mousedown event to open since closing is based on mousedown with useOutsideAlerter
             isOpen={isOpen}
         >
             {React.Children.map(props.children, child => {
+                let isCheckbox = false;
+
                 if (typeof child === 'object') {
                     if (child.props.isMain) {
-                        if (
+                        isCheckbox =
                             child.props.isCheckbox ||
                             (child.props.children &&
-                                child.props.children.type === Checkbox)
-                        ) {
+                                child.props.children.type === Checkbox);
+
+                        if (isCheckbox) {
                             className = 'cell-checkbox';
                         } else if (child.props.isId) {
                             className = 'cell-id';
@@ -76,6 +78,8 @@ const DaTableRow = props => {
                     return React.cloneElement(child, {
                         className: className,
                         isLoading: props.isLoading,
+                        onMouseDown:
+                            !isCheckbox && !isOpen ? () => setOpen(true) : null, // we need to detect mousedown event to open since closing is based on mousedown with useOutsideAlerter
                     });
                 }
             })}

--- a/src/lib/DaTableRow/DaTableRow.stories.js
+++ b/src/lib/DaTableRow/DaTableRow.stories.js
@@ -1,40 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { folder } from '../../shared/constants';
-import labels from '../../shared/labels';
 import DaTableCell from '../DaTableCell/DaTableCell';
 import Checkbox from '../Checkbox/Checkbox';
 import DaTableRow from './DaTableRow';
 
 storiesOf(folder.table + folder.sub.daTable + 'DaTableRow', module)
     .addDecorator(withKnobs)
-    .add('DaTableRow', () => (
-        <DaTableRow isActive={boolean(labels.isActive, false)}>
-            <DaTableCell>
-                <Checkbox
-                    id="select"
-                    checked={boolean(labels.isActive, false)}
-                    readOnly={true}
-                />
-            </DaTableCell>
+    .add('DaTableRow', () => {
+        const [isActive, setActive] = useState(false);
 
-            <DaTableCell isId={true}>3456</DaTableCell>
+        return (
+            <DaTableRow isActive={isActive}>
+                <DaTableCell>
+                    <Checkbox
+                        id="select"
+                        onChange={() => setActive(!isActive)}
+                        checked={isActive}
+                    />
+                </DaTableCell>
 
-            <DaTableCell isMain={false} label="Date">
-                27/05/2020
-            </DaTableCell>
+                <DaTableCell isId={true}>3456</DaTableCell>
 
-            <DaTableCell>Marie Perez</DaTableCell>
+                <DaTableCell isMain={false} label="Date">
+                    27/05/2020
+                </DaTableCell>
 
-            <DaTableCell>34.56&nbsp;€</DaTableCell>
+                <DaTableCell>Marie Perez</DaTableCell>
 
-            <DaTableCell isMain={false} label="Type">
-                Cash
-            </DaTableCell>
+                <DaTableCell>34.56&nbsp;€</DaTableCell>
 
-            <DaTableCell isMain={false} label="A very long label">
-                A very long content to display
-            </DaTableCell>
-        </DaTableRow>
-    ));
+                <DaTableCell isMain={false} label="Type">
+                    Cash
+                </DaTableCell>
+
+                <DaTableCell isMain={false} label="A very long label">
+                    <span>A very long content without bold</span>
+                </DaTableCell>
+            </DaTableRow>
+        );
+    });

--- a/src/lib/DaTableRow/__snapshots__/DaTableRow.test.js.snap
+++ b/src/lib/DaTableRow/__snapshots__/DaTableRow.test.js.snap
@@ -3,10 +3,10 @@
 exports[`renders without crashing 1`] = `
 <div
   className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
-  onMouseDown={[Function]}
 >
   <div
     className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"
+    onMouseDown={null}
   >
     <span
       className="cell-content"
@@ -40,6 +40,7 @@ exports[`renders without crashing 1`] = `
   </div>
   <div
     className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
+    onMouseDown={[Function]}
   >
     <span
       className="cell-content"
@@ -49,6 +50,7 @@ exports[`renders without crashing 1`] = `
   </div>
   <div
     className="style__DaTableCellBase-sc-1ed6rma-0 blLFYm cell-main cell-main-1"
+    onMouseDown={[Function]}
   >
     <span
       className="cell-content"
@@ -58,6 +60,7 @@ exports[`renders without crashing 1`] = `
   </div>
   <div
     className="style__DaTableCellBase-sc-1ed6rma-0 etkGNS cell-basic cell-basic-1"
+    onMouseDown={[Function]}
   >
     <span
       className="cell-content"

--- a/src/lib/DaTableRow/style/base.js
+++ b/src/lib/DaTableRow/style/base.js
@@ -78,9 +78,16 @@ const hoverStyle = css`
 `;
 
 const activeStyle = css`
-    font-weight: ${props => props.theme.font.weight.bold};
     background-color: ${props => props.theme.wab.grey10} !important;
     box-shadow: none !important;
+    
+    .cell-content {
+        font-weight: ${props => props.theme.font.weight.bold};
+
+        * {
+            font-weight: initial;
+        }
+    }
 `;
 
 const loadingStyle = css`

--- a/src/lib/DaTableRow/style/base.js
+++ b/src/lib/DaTableRow/style/base.js
@@ -80,14 +80,6 @@ const hoverStyle = css`
 const activeStyle = css`
     background-color: ${props => props.theme.wab.grey10} !important;
     box-shadow: none !important;
-    
-    .cell-content {
-        font-weight: ${props => props.theme.font.weight.bold};
-
-        * {
-            font-weight: initial;
-        }
-    }
 `;
 
 const loadingStyle = css`

--- a/src/lib/DataLegend/DataLegend.js
+++ b/src/lib/DataLegend/DataLegend.js
@@ -12,7 +12,7 @@ import {
 } from '../../shared/constants';
 import { DataLegendBase } from './style';
 
-const DataLegend = ({value, unit, children, ...rest}) => {
+const DataLegend = ({ value, unit, children, ...rest }) => {
     return (
         <DataLegendBase {...rest} isDisabled={value === 0}>
             <span className="value">{value}</span>
@@ -31,7 +31,7 @@ DataLegend.propTypes = {
     ]),
     colorTheme: PropTypes.oneOf(Object.values(colorThemeOptions)),
     colorStatus: PropTypes.oneOf(Object.values(formStatusOptions)),
-    value: PropTypes.number,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     unit: PropTypes.string,
     textSize: PropTypes.oneOf(Object.values(fontSizeOptions)),
 };

--- a/src/lib/GlobalStyle/ResetStyle.js
+++ b/src/lib/GlobalStyle/ResetStyle.js
@@ -54,6 +54,7 @@ export const ResetStyle = css`
 
     select {
         opacity: 1;
+        line-height: normal;
     }
 
     [type="checkbox"],

--- a/src/lib/Modal/__snapshots__/Modal.test.js.snap
+++ b/src/lib/Modal/__snapshots__/Modal.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders without crashing 1`] = `
     className="style__OverlayBase-sc-1jvobgw-0 lnmscb"
   />
   <div
-    className="style__ModalContentBase-atgy9x-0 bipIQD"
+    className="style__ModalContentBase-atgy9x-0 lgAvQS"
   >
     <div
       className="style__ModalBodyBase-md16g0-0 lhDNNM"

--- a/src/lib/ModalContent/__snapshots__/ModalContent.test.js.snap
+++ b/src/lib/ModalContent/__snapshots__/ModalContent.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__ModalContentBase-atgy9x-0 bipIQD"
+  className="style__ModalContentBase-atgy9x-0 lgAvQS"
 >
   <div
     className="style__ModalHeaderBase-e1z6bj-0 hqembS"

--- a/src/lib/ModalContent/style/index.js
+++ b/src/lib/ModalContent/style/index.js
@@ -4,7 +4,7 @@ import { transparentize } from 'polished';
 const ModalContentBase = styled.div`
     position: fixed;
     bottom: 0;
-    max-height: 80vh;
+    max-height: 90vh;
     width: 100%;
 
     display: grid;

--- a/src/lib/ModalProvider/__snapshots__/ModalProvider.test.js.snap
+++ b/src/lib/ModalProvider/__snapshots__/ModalProvider.test.js.snap
@@ -9,7 +9,7 @@ exports[`renders without crashing 1`] = `
     onClick={[Function]}
   />
   <div
-    className="style__ModalContentBase-atgy9x-0 bipIQD"
+    className="style__ModalContentBase-atgy9x-0 lgAvQS"
   >
     <div
       className="style__ModalBodyBase-md16g0-0 lhDNNM"


### PR DESCRIPTION
Ce qui a été fait
------

**ModalContent**

- feat: la hauteur maximale est passée de 80 à 90vh pour mieux utiliser l'espace dont on dispose et limiter les scrollbar évitables

**DataLegend**

- feat: on autorise désormais les `string` sur la props `value` (et plus uniquement les `number`)

**DaSelect**

- fix: ajout d'un reset global sur les select pour passer le line-height en "normal" par défaut, et éviter que les jambages des lettres soient coupées dans les DaSelect. Sans effet sur le composant Select qui intègre son propre line-height.

**DaTable**

- fix: le DaTableHeadCell ne duplique plus les Checkbox qui lui sont passés (et celle qui lui est passé est donc cliquable, plus de bug d'id dupliqué)
- fix: vertical-align top sur le DaTableHeadCell (le bug n'existait pas une fois que le composant était intégré dans un DaTable, mais si le composant était sans parent, les Checkbox qu'il contenait étaient décalées vers le bas).
- fix: retrait du passage du texte en gras dans une DaTableRow en isActive={true} (évite de changer la graisse des enfants - il peut y avoir des modales entières en enfants donc c'était compliqué à gérer + évite des changements de largeur du tableau).
- fix: le clic sur une cellule contenant une checkbox n'ouvre plus la DaTableRow qui la contient (ça évite qu'un clic déclenche 2 actions, à savoir cocher une case/passer la row en isActive={true} + l'ouvrir sur mobile).

**CheckboxGroup**

- fix: la prop `value` doit désormais être un tableau de valeurs (string, number, array, ce qu'on veut à l'intérieur, c'est mardi tout est permis). Cela permet au **CheckboxGroup** d'avoir plusieurs values et de passer toutes les **Checkbox** qui doivent l'être en `checked`.

**Doc**

- Amélioration des stories du DaTable pour coller aux fix sur le isActive des DaTableRow
- Ajout des couleurs senary et septenary dans la storie des couleurs (j'avais oublié de le faire quand je les avais ajoutées à la lib).

Comment tester
------

- Ouvrir les stories Modal, Select et DataLegend pour constater que j'ai pas tout cassé
- Ouvrir la storie DaSelect et constater que le contenu du select n'est plus mangé sur le bas
- Ouvrir la storie des couleurs et admirez les 2 nouvelles teintes qui se sont ajoutées
- Ouvrir les stories DaTable, DaTableRow et DaTableHeadCell : tester les props + les clics sur les Checkbox, sur desktop et mobile, en vérifiant qu'il n'y a pas d'erreur en console.