### PR TITLE
PGF-1089 : Fix datable

### DIFF
--- a/src/lib/DaTable/DaTable.js
+++ b/src/lib/DaTable/DaTable.js
@@ -22,13 +22,18 @@ const DaTable = ({
 
     if (isLoading) {
         React.Children.map(children, child => {
-            if (typeof child === 'object' && child.type === DaTableHead) {
+            if (
+                typeof child === 'object' &&
+                (child.type === DaTableHead ||
+                    child.props.className === 'DaTableHead')
+            ) {
                 columnNumber = child.props.children.length;
 
                 React.Children.map(child.props.children, (headCell, index) => {
                     if (
                         typeof headCell === 'object' &&
-                        headCell.type === DaTableHeadCell &&
+                        (headCell.type === DaTableHeadCell ||
+                            headCell.props.className === 'DaTableHeadCell') &&
                         (headCell.props.isCheckbox ||
                             (headCell.props.children &&
                                 headCell.props.children.type === Checkbox))
@@ -40,11 +45,19 @@ const DaTable = ({
         });
     } else {
         React.Children.map(children, child => {
-            if (typeof child === 'object' && child.type === DaTableBody) {
+            if (
+                typeof child === 'object' &&
+                (child.type === DaTableBody ||
+                    child.props.className === 'DaTableBody')
+            ) {
                 hasRow = false;
 
                 React.Children.map(child.props.children, row => {
-                    if (typeof row === 'object' && row.type === DaTableRow) {
+                    if (
+                        typeof row === 'object' &&
+                        (row.type === DaTableRow ||
+                            row.props.className === 'DaTableRow')
+                    ) {
                         hasRow = true;
                     }
                 });
@@ -62,7 +75,10 @@ const DaTable = ({
                 {React.Children.map(children, child => {
                     if (!child) {
                         return null;
-                    } else if (child.type === DaTableBody) {
+                    } else if (
+                        child.type === DaTableBody ||
+                        child.props.className === 'DaTableBody'
+                    ) {
                         return React.cloneElement(child, {
                             hasRow: hasRow,
                             isLoading: isLoading,

--- a/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
+++ b/src/lib/DaTable/__snapshots__/DaTable.test.js.snap
@@ -8,7 +8,7 @@ exports[`renders without crashing 1`] = `
     className="table"
   >
     <div
-      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
+      className="style__DaTableRowBase-cqmn2v-0 cOsXFb"
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
@@ -42,7 +42,7 @@ exports[`renders without crashing 1`] = `
       </div>
     </div>
     <div
-      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
+      className="style__DaTableRowBase-cqmn2v-0 cOsXFb"
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"
@@ -76,7 +76,7 @@ exports[`renders without crashing 1`] = `
       </div>
     </div>
     <div
-      className="style__DaTableRowBase-cqmn2v-0 cNBYyF"
+      className="style__DaTableRowBase-cqmn2v-0 cOsXFb"
     >
       <div
         className="style__DaTableCellBase-sc-1ed6rma-0 crwTBZ cell-id"

--- a/src/lib/DaTableBody/__snapshots__/DaTableBody.test.js.snap
+++ b/src/lib/DaTableBody/__snapshots__/DaTableBody.test.js.snap
@@ -5,7 +5,7 @@ exports[`renders without crashing 1`] = `
   className="style__DaTableBodyBase-sc-6g57ma-0 lbblkT"
 >
   <div
-    className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
+    className="style__DaTableRowBase-cqmn2v-0 jdUUFA"
   >
     <div
       className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"

--- a/src/lib/DaTableRow/DaTableRow.js
+++ b/src/lib/DaTableRow/DaTableRow.js
@@ -13,7 +13,10 @@ const DaTableRow = props => {
     let notMainCellCount = 0;
 
     React.Children.map(props.children, child => {
-        if (typeof child === 'object') {
+        if (
+            typeof child === 'object' ||
+            child.props.className === 'DaTableCell'
+        ) {
             if (child.props.isMain) {
                 mainCellCount++;
 

--- a/src/lib/DaTableRow/__snapshots__/DaTableRow.test.js.snap
+++ b/src/lib/DaTableRow/__snapshots__/DaTableRow.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__DaTableRowBase-cqmn2v-0 eMbuwm"
+  className="style__DaTableRowBase-cqmn2v-0 jdUUFA"
 >
   <div
     className="style__DaTableCellBase-sc-1ed6rma-0 gLhGfU cell-checkbox"

--- a/src/lib/DaTableRow/style/index.js
+++ b/src/lib/DaTableRow/style/index.js
@@ -10,7 +10,7 @@ import {
 
 const DaTableRowBase = styled.div`
     background-color: ${props => props.theme.wab.white10};
-    transition: all ${props => props.theme.transition.sm};
+    transition: all ${props => props.theme.transition.xxs};
     ${props => (props.isLoading ? loadingStyle : hoverStyle)};
     ${props => (props.isActive ? activeStyle : null)};
 


### PR DESCRIPTION
## Ce qui a été fait :
- ajout de la détection des classes lors de la construction automatique du DaTable et update des tests
- diminution des transitions sur le datablerow

## Comment tester :
- lancer storybook 
- vérifier que le layout desktop / mobile n'a pas bougé sur DaTable, DaTableBody,
-  puis dans le fichier DaTable.stories :
1) rajouter ce composant :
```
const MemoizedRow = memo(({ className, children, isActive }) => {
    return (
        <DaTableRow isActive={isActive} className={className}>
            {children}
        </DaTableRow>
    );
});
```
et remplacer le DaTableRow (lignes 226 - 257) 
par ```
   <MemoizedRow
        key={index}
        isActive={isActive}
        className="DaTableRow"
    >
    ```
=> vérifier que le layout n'a pas sauté (desktop et mobile)

- cleaner le fichier puis 
rajouter ce composant :
```
const MemoizedBody = memo(({ className, children }) => {
    return (
        <DaTableBody className={className}>
            {children}
        </DaTableBody>
    );
});
```
et remplacer le DaTableBody (lignes 219-268)    
=> vérifier que le layout n'a pas sauté (desktop et mobile)