### PR TITLE
PGF-1093: fix datepicker et text

### DIFF
--- a/src/lib/DatePicker/Calendar/__snapshots__/Calendar.test.js.snap
+++ b/src/lib/DatePicker/Calendar/__snapshots__/Calendar.test.js.snap
@@ -18,7 +18,7 @@ Array [
         />
       </svg>
     </button>
-    April 2021
+    April 2022
     <button
       className="style__IconBase-ak3679-0 KOHwy icon"
       onClick={[Function]}
@@ -59,7 +59,7 @@ Array [
     </div>
   </div>,
   <div
-    className="style__CalendarGridBase-sc-1qui6a5-0 ehqGoy"
+    className="style__CalendarGridBase-sc-1qui6a5-0 ehrtpv"
   >
     <button
       className="style__CalendarCellBase-sc-17uxo6m-0 cEItIt"
@@ -216,7 +216,7 @@ Array [
       22
     </button>
     <button
-      className="style__CalendarCellBase-sc-17uxo6m-0 kqyGos"
+      className="style__CalendarCellBase-sc-17uxo6m-0 cEItIt"
       onClick={[Function]}
       type="button"
     >

--- a/src/lib/DatePicker/CalendarGrid/__snapshots__/CalendarGrid.test.js.snap
+++ b/src/lib/DatePicker/CalendarGrid/__snapshots__/CalendarGrid.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders without crashing 1`] = `
 <div
-  className="style__CalendarGridBase-sc-1qui6a5-0 ehqGoy"
+  className="style__CalendarGridBase-sc-1qui6a5-0 ehrtpv"
 >
   <button
     className="style__CalendarCellBase-sc-17uxo6m-0 cEItIt"
@@ -159,7 +159,7 @@ exports[`renders without crashing 1`] = `
     22
   </button>
   <button
-    className="style__CalendarCellBase-sc-17uxo6m-0 kqyGos"
+    className="style__CalendarCellBase-sc-17uxo6m-0 cEItIt"
     onClick={[Function]}
     type="button"
   >

--- a/src/lib/DatePicker/CalendarNavbar/__snapshots__/CalendarNavbar.test.js.snap
+++ b/src/lib/DatePicker/CalendarNavbar/__snapshots__/CalendarNavbar.test.js.snap
@@ -17,7 +17,7 @@ exports[`renders without crashing 1`] = `
       />
     </svg>
   </button>
-  April 2021
+  April 2022
   <button
     className="style__IconBase-ak3679-0 KOHwy icon"
     onClick={[Function]}

--- a/src/lib/DatePicker/DatePicker.js
+++ b/src/lib/DatePicker/DatePicker.js
@@ -110,9 +110,9 @@ const DatePicker = ({
      * @param {string} value
      */
     const verifyAndChangeDateValue = value => {
-        if (value === '' && !resetDate) {
-            // we don't reset input if input is empty and there is no resetDate
+        if (!value) {
             setSelectedDate(null);
+            setInputValue('');
         } else if (!dayjs(value, dateFormat, true).isValid()) {
             resetInvalidDate();
         } else {
@@ -138,9 +138,7 @@ const DatePicker = ({
 
     // To update value dynamically if value is changed externally
     useEffect(() => {
-        if (value) {
-            verifyAndChangeDateValue(value);
-        }
+        verifyAndChangeDateValue(value);
     }, [value]);
 
     // Handle value change via CalendarCell Buttons

--- a/src/lib/DatePicker/DatePicker.stories.js
+++ b/src/lib/DatePicker/DatePicker.stories.js
@@ -19,6 +19,7 @@ import {
 import labels from '../../shared/labels';
 import { ScheduleIcon } from '../Icon/Icon';
 import DaButton from '../DaButton/DaButton';
+import ButtonGroup from '../ButtonGroup/ButtonGroup';
 import DatePicker from './DatePicker';
 import dayjs from './dayjsHelper';
 
@@ -35,12 +36,20 @@ const DatePickerWrapper = ({ hasButton, defaultValue, ...rest }) => {
             />
 
             {hasButton && (
-                <button
-                    type="button"
-                    onClick={() => setDate(dayjs().format('DD/MM/YYYY'))}
-                >
-                    <DaButton>Reset to today</DaButton>
-                </button>
+                <ButtonGroup align="left" marginTop="sm">
+                    <button type="button" onClick={() => setDate('')}>
+                        <DaButton colorTheme="tertiary" buttonSize="sm">
+                            Empty date
+                        </DaButton>
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={() => setDate(dayjs().format('DD/MM/YYYY'))}
+                    >
+                        <DaButton buttonSize="sm">Reset to today</DaButton>
+                    </button>
+                </ButtonGroup>
             )}
         </>
     );

--- a/src/lib/Text/style/base.js
+++ b/src/lib/Text/style/base.js
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import { transparentize, math } from 'polished';
 import { responsiveSpaces } from '../../../shared/spaces';
+import { lineColor } from '../../Title/style/constants';
 import { mainColor, backgroundColor, minimizeFont } from './constants';
 
 const htmlTagStyle = {
@@ -62,10 +63,19 @@ const uppercaseStyle = css`
 const color = {
     original: css`
         color: ${props => mainColor[props.colorPallet]};
+
+        &::after {
+            background-color: ${props => lineColor[props.colorPallet]};
+        }
     `,
     reverse: css`
         color: ${props => props.theme.wab.white00};
         text-shadow: 0 0 ${props => props.theme.space.sm} ${mainColor.theme};
+
+        &::after {
+            background-color: ${props =>
+                transparentize(0.6, props.theme.wab.white00)};
+        }
     `,
 };
 

--- a/src/lib/Title/style/base.js
+++ b/src/lib/Title/style/base.js
@@ -25,7 +25,7 @@ const underlineAlign = {
 const underline = css`
     position: relative;
     padding-bottom: ${props =>
-        props.theme.font.underline.space[props.textSize]};
+        props.theme.font.underline.space[props.textSize]} !important; 
     margin-bottom: ${props => props.theme.font.underline.space[props.textSize]};
 
     &::after {


### PR DESCRIPTION
## Ce qui a été fait : 
- fix sur le datepicker pour permettre l'update de la value interne avec une valeur vide (indépendamment des contraintes dates min/max/resetdate) 
- fix sur le composant text où l'underline était sans couleur et fix sur le padding nécessaire à son positionnement sous le bloc de texte (vue avec Olivia, il y a une disparition du padding notamment en mobile, due aux `${responsiveSpaces('padding')};` appliqués sur le composant `Text`. pour faire simple et limiter les risques de régressions on ne touche pas cette fonction , on n'ajoute pas d'exception dessus, on rajoute exceptionnellement un `!important` dans le bloc de style dédié à l'`underline` pour garantir le padding.)

## Comment tester :  
- `yarn start`
- tester la story du composant Text, cocher hasUnderline => cette fois il est visible, tester le positionnement (il y a bien un padding en desktop et mobile), tester le changement de couleur, l'alignement et tester que l'underline pour le composant Title fonctionne toujours correctement ausi.
- tester la story du datepicker, celle avec les boutons , l'input doit bien passer à la date du jour et à vide selon les 2 boutons